### PR TITLE
Add Cloudflare KV integration demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Object storage is available out of the box through the `cf-next-starter-r2` buck
 
 Re-run `npm run cf-typegen` after changing the binding name or adding additional buckets to keep the TypeScript definitions in sync.
 
+## Cloudflare KV integration
+
+The starter now includes a `cf-next-starter-kv` namespace for key-value storage:
+
+- `wrangler.jsonc` declares the `KV` binding and links it to the provisioned namespace (ID `418b43fc589842d088cc79d412a12222`).
+- `cloudflare-env.d.ts` exposes the binding so you can access the namespace with full type safety.
+- `src/app/api/kv/route.ts` fetches a short list of keys to validate connectivity.
+- The home page features a KV status card that lets you verify the namespace from the browser.
+
+Remember to run `npm run cf-typegen` after updating the binding name or adding additional namespaces.
+
 ## Learn More
 
 - [Next.js Documentation](https://nextjs.org/docs) – learn about features and APIs.

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -6,6 +6,7 @@ declare namespace Cloudflare {
     D1: D1Database;
     ASSETS: Fetcher;
     R2: R2Bucket;
+    KV: KVNamespace;
   }
 }
 interface CloudflareEnv extends Cloudflare.Env {}

--- a/src/app/_components/kv-status-card.tsx
+++ b/src/app/_components/kv-status-card.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+
+type KvKey = {
+  name: string;
+  expiration: number | null;
+};
+
+type KvResponse =
+  | {
+      ok: true;
+      keys: KvKey[];
+      listComplete: boolean;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function formatExpiration(expiration: number | null) {
+  if (!expiration) {
+    return null;
+  }
+
+  const expiryDate = new Date(expiration * 1000);
+  if (Number.isNaN(expiryDate.getTime())) {
+    return null;
+  }
+
+  return expiryDate.toUTCString();
+}
+
+export function KvStatusCard() {
+  const [keys, setKeys] = useState<KvKey[] | null>(null);
+  const [isListComplete, setIsListComplete] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleCheckKv = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/kv", {
+        cache: "no-store",
+      });
+      const payload = (await response.json()) as KvResponse;
+
+      if (!response.ok || !payload.ok) {
+        const message = "error" in payload ? payload.error : `Request failed with status ${response.status}`;
+        throw new Error(message);
+      }
+
+      setKeys(payload.keys);
+      setIsListComplete(payload.listComplete);
+    } catch (fetchError) {
+      const message = fetchError instanceof Error ? fetchError.message : "Failed to query KV. Please try again.";
+      setKeys(null);
+      setIsListComplete(true);
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  let statusMessage = "Click the button to list a few keys from your KV namespace.";
+
+  if (isLoading) {
+    statusMessage = "Querying KV namespace...";
+  } else if (keys) {
+    if (keys.length === 0) {
+      statusMessage = "Connected! The namespace is currently empty.";
+    } else {
+      const countLabel = keys.length === 1 ? "key" : "keys";
+      statusMessage = `Connected! Showing ${keys.length} ${countLabel} from the namespace.`;
+    }
+  } else if (error) {
+    statusMessage = error;
+  }
+
+  return (
+    <section className="w-full max-w-xl rounded-lg border border-black/[.08] dark:border-white/[.145] bg-white/60 dark:bg-black/40 p-4 shadow-sm backdrop-blur">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="w-full">
+          <h2 className="text-base font-semibold">Cloudflare KV connection check</h2>
+          <p className="mt-1 text-sm text-black/80 dark:text-white/80">{statusMessage}</p>
+
+          {keys && keys.length > 0 ? (
+            <ul className="mt-3 space-y-2 text-sm text-black/80 dark:text-white/80">
+              {keys.map((key) => (
+                <li key={key.name} className="rounded-md bg-black/[.04] p-2 dark:bg-white/[.06]">
+                  <p className="font-medium break-all">{key.name}</p>
+                  {key.expiration ? (
+                    <p className="text-xs text-black/70 dark:text-white/70">
+                      Expires {formatExpiration(key.expiration)}
+                    </p>
+                  ) : null}
+                </li>
+              ))}
+              {!isListComplete ? (
+                <li className="text-xs text-black/70 dark:text-white/70">
+                  Showing the first {keys.length} items. Add a prefix or pagination to fetch more.
+                </li>
+              ) : null}
+            </ul>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={handleCheckKv}
+          disabled={isLoading}
+          className="h-10 shrink-0 rounded-full border border-solid border-black/[.08] bg-white/70 px-4 text-sm font-medium transition-colors hover:bg-[#f2f2f2] disabled:cursor-not-allowed disabled:opacity-70 dark:border-white/[.145] dark:bg-black/40 dark:hover:bg-black/60"
+        >
+          {isLoading ? "Checking..." : "List keys"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/api/kv/route.ts
+++ b/src/app/api/kv/route.ts
@@ -1,0 +1,48 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { NextResponse } from "next/server";
+
+type KvKeyInfo = {
+  name: string;
+  expiration: number | null;
+};
+
+type KvListResponse =
+  | {
+      ok: true;
+      keys: KvKeyInfo[];
+      listComplete: boolean;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export async function GET() {
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const listResult = await env.KV.list({ limit: 5 });
+
+    const keys: KvKeyInfo[] = listResult.keys.map((key) => ({
+      name: key.name,
+      expiration: key.expiration ?? null,
+    }));
+
+    const payload: KvListResponse = {
+      ok: true,
+      keys,
+      listComplete: listResult.list_complete ?? true,
+    };
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error("Failed to query KV", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    const payload: KvListResponse = {
+      ok: false,
+      error: message,
+    };
+
+    return NextResponse.json(payload, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { D1StatusCard } from "./_components/d1-status-card";
+import { KvStatusCard } from "./_components/kv-status-card";
 import { R2StatusCard } from "./_components/r2-status-card";
 
 export default function Home() {
@@ -57,6 +58,7 @@ export default function Home() {
         <div className="flex w-full flex-col gap-4">
           <D1StatusCard />
           <R2StatusCard />
+          <KvStatusCard />
         </div>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,6 +23,13 @@
       "bucket_name": "cf-next-starter-r2"
     }
   ],
+  "kv_namespaces": [
+    {
+      "binding": "KV",
+      "id": "418b43fc589842d088cc79d412a12222",
+      "preview_id": "418b43fc589842d088cc79d412a12222"
+    }
+  ],
   "d1_databases": [
     {
       "binding": "D1",


### PR DESCRIPTION
## Summary
- register the cf-next-starter-kv namespace in Wrangler config and Cloudflare env typings
- add an API route and status card that list keys from the KV namespace
- document the new KV integration alongside the existing D1 and R2 examples

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e218b7494c832d98f36111a264c58a