### PR TITLE
feat: integrate shadcn/ui and refresh dashboard

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,14 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@opennextjs/cloudflare": "^1.3.0",
+				"@radix-ui/react-slot": "^1.1.2",
+				"class-variance-authority": "^0.7.0",
+				"clsx": "^2.1.1",
+				"lucide-react": "^0.471.1",
 				"next": "15.4.6",
 				"react": "19.1.0",
-				"react-dom": "19.1.0"
+				"react-dom": "19.1.0",
+				"tailwind-merge": "^2.5.5"
 			},
 			"devDependencies": {
 				"@eslint/eslintrc": "^3",
@@ -22,6 +27,7 @@
 				"eslint": "^9",
 				"eslint-config-next": "15.4.6",
 				"tailwindcss": "^4",
+				"tailwindcss-animate": "^1.0.7",
 				"typescript": "^5",
 				"wrangler": "^4.42.0"
 			}
@@ -9385,6 +9391,39 @@
 			"integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
 			"license": "MIT"
 		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -11168,7 +11207,7 @@
 			"version": "19.2.0",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
 			"integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.0.2"
@@ -12290,6 +12329,18 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/class-variance-authority": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+			"integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"clsx": "^2.1.1"
+			},
+			"funding": {
+				"url": "https://polar.sh/cva"
+			}
+		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -12406,6 +12457,15 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"license": "MIT"
+		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/color": {
 			"version": "4.2.3",
@@ -12554,7 +12614,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/damerau-levenshtein": {
@@ -15385,6 +15445,15 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/lucide-react": {
+			"version": "0.471.2",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.471.2.tgz",
+			"integrity": "sha512-A8fDycQxGeaSOTaI7Bm4fg8LBXO7Qr9ORAX47bDRvugCsjLIliugQO0PkKFoeAD57LIQwlWKd3NIQ3J7hYp84g==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.19",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -17597,12 +17666,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/tailwind-merge": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+			"integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/dcastil"
+			}
+		},
 		"node_modules/tailwindcss": {
 			"version": "4.1.14",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
 			"integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tailwindcss-animate": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+			"integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"tailwindcss": ">=3.0.0 || insiders"
+			}
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -12,22 +12,28 @@
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
 	},
-	"dependencies": {
-		"@opennextjs/cloudflare": "^1.3.0",
-		"next": "15.4.6",
-		"react": "19.1.0",
-		"react-dom": "19.1.0"
-	},
-	"devDependencies": {
-		"@eslint/eslintrc": "^3",
-		"@tailwindcss/postcss": "^4",
-		"@types/node": "^20.19.19",
-		"@types/react": "^19",
-		"@types/react-dom": "^19",
-		"eslint": "^9",
-		"eslint-config-next": "15.4.6",
-		"tailwindcss": "^4",
-		"typescript": "^5",
-		"wrangler": "^4.42.0"
-	}
+        "dependencies": {
+                "@opennextjs/cloudflare": "^1.3.0",
+                "@radix-ui/react-slot": "^1.1.2",
+                "class-variance-authority": "^0.7.0",
+                "clsx": "^2.1.1",
+                "lucide-react": "^0.471.1",
+                "next": "15.4.6",
+                "react": "19.1.0",
+                "react-dom": "19.1.0",
+                "tailwind-merge": "^2.5.5"
+        },
+        "devDependencies": {
+                "@eslint/eslintrc": "^3",
+                "@tailwindcss/postcss": "^4",
+                "@types/node": "^20.19.19",
+                "@types/react": "^19",
+                "@types/react-dom": "^19",
+                "eslint": "^9",
+                "eslint-config-next": "15.4.6",
+                "tailwindcss": "^4",
+                "tailwindcss-animate": "^1.0.7",
+                "typescript": "^5",
+                "wrangler": "^4.42.0"
+        }
 }

--- a/src/app/_components/d1-status-card.tsx
+++ b/src/app/_components/d1-status-card.tsx
@@ -2,6 +2,17 @@
 
 import { useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
 type TimestampResponse = {
   ok: boolean;
   currentTimestamp: string | null;
@@ -42,31 +53,63 @@ export function D1StatusCard() {
   };
 
   let statusMessage = "Click the button to verify your D1 connection.";
+  let badgeLabel = "Idle";
+  let badgeVariant: "default" | "muted" | "destructive" = "muted";
 
   if (isLoading) {
     statusMessage = "Checking database connection...";
+    badgeLabel = "Checking";
+    badgeVariant = "muted";
   } else if (timestamp) {
     statusMessage = `Connected! The database responded with ${timestamp} (UTC).`;
+    badgeLabel = "Connected";
+    badgeVariant = "default";
   } else if (error) {
     statusMessage = error;
+    badgeLabel = "Error";
+    badgeVariant = "destructive";
   }
 
   return (
-    <section className="w-full max-w-xl rounded-lg border border-black/[.08] dark:border-white/[.145] bg-white/60 dark:bg-black/40 p-4 shadow-sm backdrop-blur">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 className="text-base font-semibold">Cloudflare D1 connection check</h2>
-          <p className="mt-1 text-sm text-black/80 dark:text-white/80">{statusMessage}</p>
+    <Card className="w-full">
+      <CardHeader className="gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>Cloudflare D1</CardTitle>
+            <CardDescription>Relational storage, powered by SQLite.</CardDescription>
+          </div>
+          <Badge variant={badgeVariant}>{badgeLabel}</Badge>
         </div>
-        <button
-          type="button"
-          onClick={handleCheckConnection}
-          disabled={isLoading}
-          className="h-10 shrink-0 rounded-full border border-solid border-black/[.08] bg-white/70 px-4 text-sm font-medium transition-colors hover:bg-[#f2f2f2] disabled:cursor-not-allowed disabled:opacity-70 dark:border-white/[.145] dark:bg-black/40 dark:hover:bg-black/60"
-        >
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">{statusMessage}</p>
+        {timestamp ? (
+          <div className="rounded-lg border bg-muted/40 px-4 py-3 text-sm">
+            <p className="font-mono text-xs uppercase text-muted-foreground">
+              Last response (UTC)
+            </p>
+            <p className="mt-1 font-medium text-foreground">{timestamp}</p>
+          </div>
+        ) : null}
+      </CardContent>
+      <CardFooter className="flex flex-wrap items-center justify-between gap-3">
+        <Button onClick={handleCheckConnection} disabled={isLoading}>
           {isLoading ? "Checking..." : "Check now"}
-        </button>
-      </div>
-    </section>
+        </Button>
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+        >
+          <a
+            href="https://developers.cloudflare.com/d1/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View docs
+          </a>
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/src/app/_components/kv-status-card.tsx
+++ b/src/app/_components/kv-status-card.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 type KvKey = {
   name: string;
@@ -64,57 +75,99 @@ export function KvStatusCard() {
     }
   };
 
-  let statusMessage = "Click the button to list a few keys from your KV namespace.";
-
-  if (isLoading) {
-    statusMessage = "Querying KV namespace...";
-  } else if (keys) {
-    if (keys.length === 0) {
-      statusMessage = "Connected! The namespace is currently empty.";
-    } else {
-      const countLabel = keys.length === 1 ? "key" : "keys";
-      statusMessage = `Connected! Showing ${keys.length} ${countLabel} from the namespace.`;
+  const status = useMemo(() => {
+    if (isLoading) {
+      return {
+        message: "Querying KV namespace...",
+        badge: "Checking",
+        variant: "muted" as const,
+      };
     }
-  } else if (error) {
-    statusMessage = error;
-  }
+
+    if (keys) {
+      if (keys.length === 0) {
+        return {
+          message: "Connected! The namespace is currently empty.",
+          badge: "Connected",
+          variant: "default" as const,
+        };
+      }
+
+      const countLabel = keys.length === 1 ? "key" : "keys";
+      return {
+        message: `Connected! Showing ${keys.length} ${countLabel} from the namespace.`,
+        badge: "Connected",
+        variant: "default" as const,
+      };
+    }
+
+    if (error) {
+      return {
+        message: error,
+        badge: "Error",
+        variant: "destructive" as const,
+      };
+    }
+
+    return {
+      message: "Click the button to list a few keys from your KV namespace.",
+      badge: "Idle",
+      variant: "muted" as const,
+    };
+  }, [error, isLoading, keys]);
 
   return (
-    <section className="w-full max-w-xl rounded-lg border border-black/[.08] dark:border-white/[.145] bg-white/60 dark:bg-black/40 p-4 shadow-sm backdrop-blur">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="w-full">
-          <h2 className="text-base font-semibold">Cloudflare KV connection check</h2>
-          <p className="mt-1 text-sm text-black/80 dark:text-white/80">{statusMessage}</p>
-
-          {keys && keys.length > 0 ? (
-            <ul className="mt-3 space-y-2 text-sm text-black/80 dark:text-white/80">
+    <Card className="w-full">
+      <CardHeader className="gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>Cloudflare KV</CardTitle>
+            <CardDescription>Ultra-fast key-value storage at the edge.</CardDescription>
+          </div>
+          <Badge variant={status.variant}>{status.badge}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">{status.message}</p>
+        {keys && keys.length > 0 ? (
+          <div className="space-y-2">
+            <ul className="space-y-2">
               {keys.map((key) => (
-                <li key={key.name} className="rounded-md bg-black/[.04] p-2 dark:bg-white/[.06]">
-                  <p className="font-medium break-all">{key.name}</p>
+                <li
+                  key={key.name}
+                  className="rounded-lg border bg-muted/40 px-4 py-3 text-sm"
+                >
+                  <p className="font-medium text-foreground break-all">{key.name}</p>
                   {key.expiration ? (
-                    <p className="text-xs text-black/70 dark:text-white/70">
+                    <p className="text-xs text-muted-foreground">
                       Expires {formatExpiration(key.expiration)}
                     </p>
                   ) : null}
                 </li>
               ))}
-              {!isListComplete ? (
-                <li className="text-xs text-black/70 dark:text-white/70">
-                  Showing the first {keys.length} items. Add a prefix or pagination to fetch more.
-                </li>
-              ) : null}
             </ul>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          onClick={handleCheckKv}
-          disabled={isLoading}
-          className="h-10 shrink-0 rounded-full border border-solid border-black/[.08] bg-white/70 px-4 text-sm font-medium transition-colors hover:bg-[#f2f2f2] disabled:cursor-not-allowed disabled:opacity-70 dark:border-white/[.145] dark:bg-black/40 dark:hover:bg-black/60"
-        >
+            {!isListComplete ? (
+              <Badge variant="outline" className="w-fit">
+                Partial results
+              </Badge>
+            ) : null}
+          </div>
+        ) : null}
+      </CardContent>
+      <CardFooter className="flex flex-wrap items-center justify-between gap-3">
+        <Button onClick={handleCheckKv} disabled={isLoading}>
           {isLoading ? "Checking..." : "List keys"}
-        </button>
-      </div>
-    </section>
+        </Button>
+        <Button asChild variant="ghost" size="sm">
+          <a
+            href="https://developers.cloudflare.com/kv/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View docs
+          </a>
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,91 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-ring: hsl(var(--ring));
 }
 
-@media (prefers-color-scheme: dark) {
+@layer base {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: 210 25% 98%;
+    --foreground: 224 71.4% 4.1%;
+    --muted: 214.3 31.8% 91.4%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 224 71.4% 4.1%;
+    --card: 0 0% 100%;
+    --card-foreground: 224 71.4% 4.1%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 20% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 20% 98%;
+    --ring: 215 20.2% 65.1%;
+    --radius: 0.75rem;
+  }
+
+  .dark {
+    --background: 224 71.4% 4.1%;
+    --foreground: 210 20% 98%;
+    --muted: 215 27.9% 16.9%;
+    --muted-foreground: 217.9 10.6% 64.9%;
+    --popover: 224 71.4% 4.1%;
+    --popover-foreground: 210 20% 98%;
+    --card: 224 71.4% 4.1%;
+    --card-foreground: 210 20% 98%;
+    --border: 215 27.9% 16.9%;
+    --input: 215 27.9% 16.9%;
+    --primary: 210 20% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 215 27.9% 16.9%;
+    --secondary-foreground: 210 20% 98%;
+    --accent: 215 27.9% 16.9%;
+    --accent-foreground: 210 20% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 85.7% 97.3%;
+    --ring: 215 20.2% 65.1%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    font-family: var(--font-sans, system-ui), -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif;
+    font-feature-settings: "rlig" 1, "calt" 1;
   }
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+@utility border-border {
+  border-color: hsl(var(--border));
+}
+
+@utility ring-offset-background {
+  --tw-ring-offset-color: hsl(var(--background));
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+
+import { cn } from "@/lib/utils";
+
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,9 +26,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={cn(
+          "min-h-screen bg-background font-sans text-foreground antialiased",
+          geistSans.variable,
+          geistMono.variable
+        )}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,113 +1,106 @@
-import Image from "next/image";
+import Link from "next/link";
+import {
+  ArrowUpRight,
+  Boxes,
+  CloudLightning,
+  Database,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
 import { D1StatusCard } from "./_components/d1-status-card";
 import { KvStatusCard } from "./_components/kv-status-card";
 import { R2StatusCard } from "./_components/r2-status-card";
 
+const highlights = [
+  {
+    title: "Edge-first runtime",
+    description: "Serve Next.js App Router routes with near-zero cold starts on Cloudflare Workers.",
+    icon: CloudLightning,
+  },
+  {
+    title: "Full data stack",
+    description: "Ship with production-ready access to D1, R2, and KV from a single codebase.",
+    icon: Database,
+  },
+  {
+    title: "Opinionated DX",
+    description: "Prewired linting, type-safety, and shadcn/ui primitives for fast iteration.",
+    icon: Boxes,
+  },
+];
+
 export default function Home() {
-
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+    <main className="container flex flex-col gap-16 py-16">
+      <section className="flex flex-col gap-8 text-center sm:text-left">
+        <div className="flex justify-center sm:justify-start">
+          <Badge className="gap-2 px-4 py-1 text-sm" variant="secondary">
+            Cloudflare Workers • Next.js 15
+          </Badge>
         </div>
 
-        <div className="flex w-full flex-col gap-4">
+        <div className="space-y-4">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            Cloudflare + Next.js starter, upgraded with shadcn/ui
+          </h1>
+          <p className="mx-auto max-w-3xl text-base text-muted-foreground sm:text-lg">
+            Deploy a modern, edge-native application with polished UI primitives, instant data checks,
+            and a toolkit tuned for the Cloudflare stack. Start iterating in minutes with production-ready defaults.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:justify-start">
+          <Button asChild size="lg">
+            <Link href="https://dash.cloudflare.com/sign-up" target="_blank" rel="noreferrer">
+              Deploy to Cloudflare
+              <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden />
+            </Link>
+          </Button>
+          <Button asChild size="lg" variant="outline">
+            <Link href="https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/" target="_blank" rel="noreferrer">
+              Deployment guide
+            </Link>
+          </Button>
+        </div>
+      </section>
+
+      <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {highlights.map((feature) => (
+          <Card key={feature.title} className="h-full">
+            <CardHeader className="flex-row items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <feature.icon className="h-5 w-5" aria-hidden />
+              </div>
+              <div>
+                <CardTitle className="text-lg">{feature.title}</CardTitle>
+                <CardDescription>{feature.description}</CardDescription>
+              </div>
+            </CardHeader>
+          </Card>
+        ))}
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold tracking-tight">Verify your Cloudflare bindings</h2>
+          <p className="text-muted-foreground">
+            Run the built-in health checks to confirm each service is wired up to your environment.
+          </p>
+        </div>
+        <div className="grid gap-6 xl:grid-cols-2">
           <D1StatusCard />
           <R2StatusCard />
           <KvStatusCard />
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground shadow",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        destructive: "border-transparent bg-destructive text-destructive-foreground shadow-sm",
+        outline: "text-foreground",
+        muted: "border-transparent bg-muted text-muted-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size }), className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,79 @@
+import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "1.5rem",
+      screens: {
+        "2xl": "1280px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [animatePlugin],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add shadcn/ui configuration, theme tokens, and utility helpers
- refresh the landing experience and health check cards to use shadcn/ui primitives
- introduce reusable button, badge, and card components for future UI work

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e21f01e5b8832da24d97977b0433cd