### PR TITLE
chore: add preview resource bindings to wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,6 +39,30 @@
   ],
   "observability": {
     "enabled": true
+  },
+  "env": {
+    "preview": {
+      "r2_buckets": [
+        {
+          "binding": "R2",
+          "bucket_name": "cf-next-starter-r2-preview"
+        }
+      ],
+      "kv_namespaces": [
+        {
+          "binding": "KV",
+          "id": "b06fb021a5a24543849cb12f8fd504c8",
+          "preview_id": "b06fb021a5a24543849cb12f8fd504c8"
+        }
+      ],
+      "d1_databases": [
+        {
+          "binding": "D1",
+          "database_name": "cf-next-starter-d1-preview",
+          "database_id": "58724aa6-fa82-43fb-8f5a-75b394cb38dd"
+        }
+      ]
+    }
   }
   /**
    * Smart Placement

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -51,8 +51,7 @@
       "kv_namespaces": [
         {
           "binding": "KV",
-          "id": "b06fb021a5a24543849cb12f8fd504c8",
-          "preview_id": "b06fb021a5a24543849cb12f8fd504c8"
+          "id": "b06fb021a5a24543849cb12f8fd504c8"
         }
       ],
       "d1_databases": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,8 +26,7 @@
   "kv_namespaces": [
     {
       "binding": "KV",
-      "id": "418b43fc589842d088cc79d412a12222",
-      "preview_id": "418b43fc589842d088cc79d412a12222"
+      "id": "418b43fc589842d088cc79d412a12222"
     }
   ],
   "d1_databases": [


### PR DESCRIPTION
## Summary
- add a wrangler "preview" environment that points to the preview R2 bucket, KV namespace, and D1 database

## Testing
- not run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68e251340880832d83f308dcad36faa4