### PR TITLE
feat: add Drizzle ORM integration for D1 endpoint

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,14 @@
+import "dotenv/config";
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  out: "./drizzle",
+  schema: "./src/db/schema.ts",
+  dialect: "sqlite",
+  driver: "d1-http",
+  dbCredentials: {
+    accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+    databaseId: process.env.CLOUDFLARE_DATABASE_ID!,
+    token: process.env.CLOUDFLARE_D1_TOKEN!,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@opennextjs/cloudflare": "^1.3.0",
 				"class-variance-authority": "^0.7.0",
 				"clsx": "^2.1.1",
+				"drizzle-orm": "^0.44.6",
 				"lucide-react": "^0.474.0",
 				"next": "15.4.6",
 				"react": "19.1.0",
@@ -23,9 +24,11 @@
 				"@types/node": "^20.19.19",
 				"@types/react": "^19",
 				"@types/react-dom": "^19",
+				"drizzle-kit": "^0.31.5",
 				"eslint": "^9",
 				"eslint-config-next": "15.4.6",
 				"tailwindcss": "^4",
+				"tsx": "^4.19.2",
 				"typescript": "^5",
 				"wrangler": "^4.42.0"
 			}
@@ -7744,6 +7747,13 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"node_modules/@drizzle-team/brocli": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+			"integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/@ecies/ciphers": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.4.tgz",
@@ -7789,6 +7799,442 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+			"integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+			"deprecated": "Merged into tsx: https://tsx.is",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.18.20",
+				"source-map-support": "^0.5.21"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+			"integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+			"integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+			"integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+			"integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+			"integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+			"integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+			"integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+			"integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+			"integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+			"integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+			"integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+			"integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+			"integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+			"integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+			"integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+			"integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+			"integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+			"integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+			"integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+			"integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+			"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/android-arm": "0.18.20",
+				"@esbuild/android-arm64": "0.18.20",
+				"@esbuild/android-x64": "0.18.20",
+				"@esbuild/darwin-arm64": "0.18.20",
+				"@esbuild/darwin-x64": "0.18.20",
+				"@esbuild/freebsd-arm64": "0.18.20",
+				"@esbuild/freebsd-x64": "0.18.20",
+				"@esbuild/linux-arm": "0.18.20",
+				"@esbuild/linux-arm64": "0.18.20",
+				"@esbuild/linux-ia32": "0.18.20",
+				"@esbuild/linux-loong64": "0.18.20",
+				"@esbuild/linux-mips64el": "0.18.20",
+				"@esbuild/linux-ppc64": "0.18.20",
+				"@esbuild/linux-riscv64": "0.18.20",
+				"@esbuild/linux-s390x": "0.18.20",
+				"@esbuild/linux-x64": "0.18.20",
+				"@esbuild/netbsd-x64": "0.18.20",
+				"@esbuild/openbsd-x64": "0.18.20",
+				"@esbuild/sunos-x64": "0.18.20",
+				"@esbuild/win32-arm64": "0.18.20",
+				"@esbuild/win32-ia32": "0.18.20",
+				"@esbuild/win32-x64": "0.18.20"
+			}
+		},
+		"node_modules/@esbuild-kit/esm-loader": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+			"integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+			"deprecated": "Merged into tsx: https://tsx.is",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@esbuild-kit/core-utils": "^3.3.2",
+				"get-tsconfig": "^4.7.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -12761,6 +13207,147 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"node_modules/drizzle-kit": {
+			"version": "0.31.5",
+			"resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.5.tgz",
+			"integrity": "sha512-+CHgPFzuoTQTt7cOYCV6MOw2w8vqEn/ap1yv4bpZOWL03u7rlVRQhUY0WYT3rHsgVTXwYQDZaSUJSQrMBUKuWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@drizzle-team/brocli": "^0.10.2",
+				"@esbuild-kit/esm-loader": "^2.5.5",
+				"esbuild": "^0.25.4",
+				"esbuild-register": "^3.5.0"
+			},
+			"bin": {
+				"drizzle-kit": "bin.cjs"
+			}
+		},
+		"node_modules/drizzle-orm": {
+			"version": "0.44.6",
+			"resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.6.tgz",
+			"integrity": "sha512-uy6uarrrEOc9K1u5/uhBFJbdF5VJ5xQ/Yzbecw3eAYOunv5FDeYkR2m8iitocdHBOHbvorviKOW5GVw0U1j4LQ==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@aws-sdk/client-rds-data": ">=3",
+				"@cloudflare/workers-types": ">=4",
+				"@electric-sql/pglite": ">=0.2.0",
+				"@libsql/client": ">=0.10.0",
+				"@libsql/client-wasm": ">=0.10.0",
+				"@neondatabase/serverless": ">=0.10.0",
+				"@op-engineering/op-sqlite": ">=2",
+				"@opentelemetry/api": "^1.4.1",
+				"@planetscale/database": ">=1.13",
+				"@prisma/client": "*",
+				"@tidbcloud/serverless": "*",
+				"@types/better-sqlite3": "*",
+				"@types/pg": "*",
+				"@types/sql.js": "*",
+				"@upstash/redis": ">=1.34.7",
+				"@vercel/postgres": ">=0.8.0",
+				"@xata.io/client": "*",
+				"better-sqlite3": ">=7",
+				"bun-types": "*",
+				"expo-sqlite": ">=14.0.0",
+				"gel": ">=2",
+				"knex": "*",
+				"kysely": "*",
+				"mysql2": ">=2",
+				"pg": ">=8",
+				"postgres": ">=3",
+				"sql.js": ">=1",
+				"sqlite3": ">=5"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/client-rds-data": {
+					"optional": true
+				},
+				"@cloudflare/workers-types": {
+					"optional": true
+				},
+				"@electric-sql/pglite": {
+					"optional": true
+				},
+				"@libsql/client": {
+					"optional": true
+				},
+				"@libsql/client-wasm": {
+					"optional": true
+				},
+				"@neondatabase/serverless": {
+					"optional": true
+				},
+				"@op-engineering/op-sqlite": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@planetscale/database": {
+					"optional": true
+				},
+				"@prisma/client": {
+					"optional": true
+				},
+				"@tidbcloud/serverless": {
+					"optional": true
+				},
+				"@types/better-sqlite3": {
+					"optional": true
+				},
+				"@types/pg": {
+					"optional": true
+				},
+				"@types/sql.js": {
+					"optional": true
+				},
+				"@upstash/redis": {
+					"optional": true
+				},
+				"@vercel/postgres": {
+					"optional": true
+				},
+				"@xata.io/client": {
+					"optional": true
+				},
+				"better-sqlite3": {
+					"optional": true
+				},
+				"bun-types": {
+					"optional": true
+				},
+				"expo-sqlite": {
+					"optional": true
+				},
+				"gel": {
+					"optional": true
+				},
+				"knex": {
+					"optional": true
+				},
+				"kysely": {
+					"optional": true
+				},
+				"mysql2": {
+					"optional": true
+				},
+				"pg": {
+					"optional": true
+				},
+				"postgres": {
+					"optional": true
+				},
+				"prisma": {
+					"optional": true
+				},
+				"sql.js": {
+					"optional": true
+				},
+				"sqlite3": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -13072,6 +13659,19 @@
 				"@esbuild/win32-arm64": "0.25.4",
 				"@esbuild/win32-ia32": "0.25.4",
 				"@esbuild/win32-x64": "0.25.4"
+			}
+		},
+		"node_modules/esbuild-register": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
+			"integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"peerDependencies": {
+				"esbuild": ">=0.12 <1"
 			}
 		},
 		"node_modules/escalade": {
@@ -17785,6 +18385,26 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.20.6",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+			"integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.25.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@opennextjs/cloudflare": "^1.3.0",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
+		"drizzle-orm": "^0.44.6",
 		"lucide-react": "^0.474.0",
 		"next": "15.4.6",
 		"react": "19.1.0",
@@ -28,9 +29,11 @@
 		"@types/node": "^20.19.19",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
+		"drizzle-kit": "^0.31.5",
 		"eslint": "^9",
 		"eslint-config-next": "15.4.6",
 		"tailwindcss": "^4",
+		"tsx": "^4.19.2",
 		"typescript": "^5",
 		"wrangler": "^4.42.0"
 	}

--- a/src/app/api/d1/route.ts
+++ b/src/app/api/d1/route.ts
@@ -1,5 +1,8 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
+
+import { createDb } from "@/db/client";
 
 type TimestampRow = {
   currentTimestamp: string;
@@ -8,9 +11,10 @@ type TimestampRow = {
 export async function GET() {
   try {
     const { env } = await getCloudflareContext({ async: true });
-    const row = await env.D1.prepare(
-      "SELECT datetime('now') as currentTimestamp",
-    ).first<TimestampRow>();
+    const db = createDb(env.D1);
+    const row = await db.get<TimestampRow>(
+      sql`SELECT datetime('now') as currentTimestamp`,
+    );
 
     return NextResponse.json({
       ok: true,

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,5 @@
+import { drizzle } from "drizzle-orm/d1";
+
+export function createDb(database: D1Database) {
+  return drizzle(database);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,7 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const usersTable = sqliteTable("users", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+});


### PR DESCRIPTION
## Summary
- add Drizzle ORM and tooling dependencies plus configuration for the Cloudflare D1 database
- scaffold a reusable Drizzle client and schema for future queries
- refactor the D1 API route to fetch timestamps through Drizzle using the env.D1 binding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e28bdffae4832d8a80444a2ed33def