### PR TITLE
Add Playwright integration and CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  unit-tests:
     name: Vitest & lint
     runs-on: ubuntu-latest
 
@@ -23,9 +23,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
 
       - name: Lint
         run: npm run lint
@@ -50,3 +47,42 @@ jobs:
           name: Vitest
           path: reports/vitest-junit.xml
           reporter: jest-junit
+
+  playwright:
+    name: Playwright integration & e2e
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:playwright:ci
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: results.xml
+          if-no-files-found: warn
+
+      - name: Playwright Test Report
+        uses: dorny/test-reporter@v2
+        if: ${{ !cancelled() }}
+        with:
+          name: Playwright
+          path: results.xml
+          reporter: junit

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 			"devDependencies": {
 				"@chromatic-com/storybook": "^4.1.1",
 				"@eslint/eslintrc": "^3",
+				"@playwright/test": "^1.55.1",
 				"@storybook/addon-a11y": "^9.1.10",
 				"@storybook/addon-docs": "^9.1.10",
 				"@storybook/addon-onboarding": "^9.1.10",
@@ -10548,6 +10549,22 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@playwright/test": {
+			"version": "1.55.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+			"integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.55.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@polka/url": {
 			"version": "1.0.0-next.29",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -19944,7 +19961,7 @@
 			"version": "1.55.1",
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
 			"integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright-core": "1.55.1"
@@ -19963,7 +19980,7 @@
 			"version": "1.55.1",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
 			"integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
-		"test:ci": "vitest run --coverage --reporter=default --reporter=junit --outputFile=reports/vitest-junit.xml"
+		"test:ci": "vitest run --coverage --reporter=default --reporter=junit --outputFile=reports/vitest-junit.xml",
+		"test:playwright": "playwright test",
+		"test:playwright:ci": "PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml playwright test --reporter=junit"
 	},
 	"dependencies": {
 		"@opennextjs/cloudflare": "^1.3.0",
@@ -61,6 +63,7 @@
 		"tailwindcss": "^4",
 		"typescript": "^5",
 		"vitest": "^3.2.4",
-		"wrangler": "^4.42.0"
+		"wrangler": "^4.42.0",
+		"@playwright/test": "^1.55.1"
 	}
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const webServerCommand = 'npm run cf:dev';
+const webServerPort = 8787;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  reporter: process.env.CI
+    ? [['junit', { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME ?? 'playwright-results.xml' }], ['list']]
+    : 'list',
+  webServer: {
+    command: webServerCommand,
+    port: webServerPort,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180 * 1000,
+  },
+  use: {
+    baseURL: `http://127.0.0.1:${webServerPort}`,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'integration',
+      testDir: './tests/integration',
+      testMatch: '**/*.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'e2e',
+      testDir: './tests/e2e',
+      testMatch: '**/*.e2e.ts',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/e2e/example.e2e.ts
+++ b/tests/e2e/example.e2e.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has expected title', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Cloudflare \+ Next\.js starter/i);
+});

--- a/tests/integration/example.spec.ts
+++ b/tests/integration/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('integration example passes', async () => {
+  const result = [1, 2, 3].map((value) => value * 2);
+  expect(result).toEqual([2, 4, 6]);
+});


### PR DESCRIPTION
## Summary
- configure Playwright with integration and e2e projects plus Cloudflare dev server
- add sample integration and end-to-end specs under tests/
- extend CI to run Playwright tests in parallel with existing lint and unit checks

## Testing
- PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --list

------
https://chatgpt.com/codex/tasks/task_e_68e355e31ea4832d9ea3ea75400935a2