### PR TITLE
fix: align auth client typing for resend flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,28 @@ GitHub Actions (`.github/workflows/test.yml`) guard every push and pull request:
 - 🛡️ **Type-safe platform bindings** – `cloudflare-env.d.ts` enumerates every Worker binding, keeping runtime configuration transparent and type checked.
 - 📦 **Modern full-stack architecture** – App Router layouts, server actions, and API routes come scaffolded for edge-friendly experiences across regions.
 - 🔁 **CI/CD friendly** – Wrangler-compatible commands, artifact uploads, and typed environment contracts keep your GitHub → Cloudflare workflow smooth and auditable.
+
+## Email Verification via Resend
+
+The Better Auth sample flow ships with mandatory email verification. Configure a Resend account and provide the following environment variables (for local development, place them in `.dev.vars`; for deployments, set them in the Worker binding settings):
+
+- `RESEND_API_KEY` – Required. The API key generated in the Resend dashboard.
+- `RESEND_FROM_EMAIL` – Required. A verified sender email address (for example, `login@yourdomain.com`).
+- `RESEND_FROM_NAME` – Optional. Friendly display name for outgoing messages.
+
+The verification message is implemented as a React email template in [`src/emails/verification-email.tsx`](src/emails/verification-email.tsx), with a Storybook preview under `Emails/VerificationEmail` to make visual tweaks fast.
+
+### Cloudflare environment bindings vs. `process.env`
+
+Cloudflare Workers inject bindings through the `env` argument that surfaces in API routes, middleware, and server actions—**not** `process.env`. That is why the Resend helper receives `env: CloudflareEnv` and reads `env.RESEND_API_KEY`, mirroring the way any Worker binding is accessed at runtime. Node-based tooling (such as `drizzle.config.ts` or Playwright) still uses `process.env` because those scripts execute in your local shell.
+
+Set secrets like `RESEND_API_KEY` with `wrangler secret put RESEND_API_KEY`. Non-secret defaults (for example `RESEND_FROM_EMAIL`) can live in the `vars` block of `wrangler.jsonc`, or you can manage them via the dashboard UI. The starter currently declares D1, R2, and KV bindings in `wrangler.jsonc`; add the Resend values there if you want reproducible previews:
+
+```jsonc
+  "vars": {
+    "RESEND_FROM_EMAIL": "login@example.com",
+    "RESEND_FROM_NAME": "Cloudflare Next Starter"
+  }
+```
+
+Run `npm run cf-typegen` whenever you add or update bindings so the generated `cloudflare-env.d.ts` stays current.

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -7,6 +7,9 @@ declare namespace Cloudflare {
     ASSETS: Fetcher;
     R2: R2Bucket;
     KV: KVNamespace;
+    RESEND_API_KEY?: string;
+    RESEND_FROM_EMAIL?: string;
+    RESEND_FROM_NAME?: string;
   }
 }
 interface CloudflareEnv extends Cloudflare.Env {}
@@ -35,165 +38,176 @@ declare var onmessage: never;
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException)
  */
 declare class DOMException extends Error {
-    constructor(message?: string, name?: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/message) */
-    readonly message: string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/name) */
-    readonly name: string;
-    /**
-     * @deprecated
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/code)
-     */
-    readonly code: number;
-    static readonly INDEX_SIZE_ERR: number;
-    static readonly DOMSTRING_SIZE_ERR: number;
-    static readonly HIERARCHY_REQUEST_ERR: number;
-    static readonly WRONG_DOCUMENT_ERR: number;
-    static readonly INVALID_CHARACTER_ERR: number;
-    static readonly NO_DATA_ALLOWED_ERR: number;
-    static readonly NO_MODIFICATION_ALLOWED_ERR: number;
-    static readonly NOT_FOUND_ERR: number;
-    static readonly NOT_SUPPORTED_ERR: number;
-    static readonly INUSE_ATTRIBUTE_ERR: number;
-    static readonly INVALID_STATE_ERR: number;
-    static readonly SYNTAX_ERR: number;
-    static readonly INVALID_MODIFICATION_ERR: number;
-    static readonly NAMESPACE_ERR: number;
-    static readonly INVALID_ACCESS_ERR: number;
-    static readonly VALIDATION_ERR: number;
-    static readonly TYPE_MISMATCH_ERR: number;
-    static readonly SECURITY_ERR: number;
-    static readonly NETWORK_ERR: number;
-    static readonly ABORT_ERR: number;
-    static readonly URL_MISMATCH_ERR: number;
-    static readonly QUOTA_EXCEEDED_ERR: number;
-    static readonly TIMEOUT_ERR: number;
-    static readonly INVALID_NODE_TYPE_ERR: number;
-    static readonly DATA_CLONE_ERR: number;
-    get stack(): any;
-    set stack(value: any);
+  constructor(message?: string, name?: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/message) */
+  readonly message: string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/name) */
+  readonly name: string;
+  /**
+   * @deprecated
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/code)
+   */
+  readonly code: number;
+  static readonly INDEX_SIZE_ERR: number;
+  static readonly DOMSTRING_SIZE_ERR: number;
+  static readonly HIERARCHY_REQUEST_ERR: number;
+  static readonly WRONG_DOCUMENT_ERR: number;
+  static readonly INVALID_CHARACTER_ERR: number;
+  static readonly NO_DATA_ALLOWED_ERR: number;
+  static readonly NO_MODIFICATION_ALLOWED_ERR: number;
+  static readonly NOT_FOUND_ERR: number;
+  static readonly NOT_SUPPORTED_ERR: number;
+  static readonly INUSE_ATTRIBUTE_ERR: number;
+  static readonly INVALID_STATE_ERR: number;
+  static readonly SYNTAX_ERR: number;
+  static readonly INVALID_MODIFICATION_ERR: number;
+  static readonly NAMESPACE_ERR: number;
+  static readonly INVALID_ACCESS_ERR: number;
+  static readonly VALIDATION_ERR: number;
+  static readonly TYPE_MISMATCH_ERR: number;
+  static readonly SECURITY_ERR: number;
+  static readonly NETWORK_ERR: number;
+  static readonly ABORT_ERR: number;
+  static readonly URL_MISMATCH_ERR: number;
+  static readonly QUOTA_EXCEEDED_ERR: number;
+  static readonly TIMEOUT_ERR: number;
+  static readonly INVALID_NODE_TYPE_ERR: number;
+  static readonly DATA_CLONE_ERR: number;
+  get stack(): any;
+  set stack(value: any);
 }
 type WorkerGlobalScopeEventMap = {
-    fetch: FetchEvent;
-    scheduled: ScheduledEvent;
-    queue: QueueEvent;
-    unhandledrejection: PromiseRejectionEvent;
-    rejectionhandled: PromiseRejectionEvent;
+  fetch: FetchEvent;
+  scheduled: ScheduledEvent;
+  queue: QueueEvent;
+  unhandledrejection: PromiseRejectionEvent;
+  rejectionhandled: PromiseRejectionEvent;
 };
 declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEventMap> {
-    EventTarget: typeof EventTarget;
+  EventTarget: typeof EventTarget;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console) */
 interface Console {
-    "assert"(condition?: boolean, ...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/clear_static) */
-    clear(): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
-    count(label?: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
-    countReset(label?: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
-    debug(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/dir_static) */
-    dir(item?: any, options?: any): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/dirxml_static) */
-    dirxml(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/error_static) */
-    error(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
-    group(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
-    groupCollapsed(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
-    groupEnd(): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
-    info(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/log_static) */
-    log(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/table_static) */
-    table(tabularData?: any, properties?: string[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
-    time(label?: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
-    timeEnd(label?: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
-    timeLog(label?: string, ...data: any[]): void;
-    timeStamp(label?: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
-    trace(...data: any[]): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/warn_static) */
-    warn(...data: any[]): void;
+  "assert"(condition?: boolean, ...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/clear_static) */
+  clear(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/count_static) */
+  count(label?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/countReset_static) */
+  countReset(label?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/debug_static) */
+  debug(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/dir_static) */
+  dir(item?: any, options?: any): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/dirxml_static) */
+  dirxml(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/error_static) */
+  error(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/group_static) */
+  group(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupCollapsed_static) */
+  groupCollapsed(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/groupEnd_static) */
+  groupEnd(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
+  info(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/log_static) */
+  log(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/table_static) */
+  table(tabularData?: any, properties?: string[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/time_static) */
+  time(label?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeEnd_static) */
+  timeEnd(label?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/timeLog_static) */
+  timeLog(label?: string, ...data: any[]): void;
+  timeStamp(label?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/trace_static) */
+  trace(...data: any[]): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/warn_static) */
+  warn(...data: any[]): void;
 }
 declare const console: Console;
 type BufferSource = ArrayBufferView | ArrayBuffer;
-type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
 declare namespace WebAssembly {
-    class CompileError extends Error {
-        constructor(message?: string);
-    }
-    class RuntimeError extends Error {
-        constructor(message?: string);
-    }
-    type ValueType = "anyfunc" | "externref" | "f32" | "f64" | "i32" | "i64" | "v128";
-    interface GlobalDescriptor {
-        value: ValueType;
-        mutable?: boolean;
-    }
-    class Global {
-        constructor(descriptor: GlobalDescriptor, value?: any);
-        value: any;
-        valueOf(): any;
-    }
-    type ImportValue = ExportValue | number;
-    type ModuleImports = Record<string, ImportValue>;
-    type Imports = Record<string, ModuleImports>;
-    type ExportValue = Function | Global | Memory | Table;
-    type Exports = Record<string, ExportValue>;
-    class Instance {
-        constructor(module: Module, imports?: Imports);
-        readonly exports: Exports;
-    }
-    interface MemoryDescriptor {
-        initial: number;
-        maximum?: number;
-        shared?: boolean;
-    }
-    class Memory {
-        constructor(descriptor: MemoryDescriptor);
-        readonly buffer: ArrayBuffer;
-        grow(delta: number): number;
-    }
-    type ImportExportKind = "function" | "global" | "memory" | "table";
-    interface ModuleExportDescriptor {
-        kind: ImportExportKind;
-        name: string;
-    }
-    interface ModuleImportDescriptor {
-        kind: ImportExportKind;
-        module: string;
-        name: string;
-    }
-    abstract class Module {
-        static customSections(module: Module, sectionName: string): ArrayBuffer[];
-        static exports(module: Module): ModuleExportDescriptor[];
-        static imports(module: Module): ModuleImportDescriptor[];
-    }
-    type TableKind = "anyfunc" | "externref";
-    interface TableDescriptor {
-        element: TableKind;
-        initial: number;
-        maximum?: number;
-    }
-    class Table {
-        constructor(descriptor: TableDescriptor, value?: any);
-        readonly length: number;
-        get(index: number): any;
-        grow(delta: number, value?: any): number;
-        set(index: number, value?: any): void;
-    }
-    function instantiate(module: Module, imports?: Imports): Promise<Instance>;
-    function validate(bytes: BufferSource): boolean;
+  class CompileError extends Error {
+    constructor(message?: string);
+  }
+  class RuntimeError extends Error {
+    constructor(message?: string);
+  }
+  type ValueType = "anyfunc" | "externref" | "f32" | "f64" | "i32" | "i64" | "v128";
+  interface GlobalDescriptor {
+    value: ValueType;
+    mutable?: boolean;
+  }
+  class Global {
+    constructor(descriptor: GlobalDescriptor, value?: any);
+    value: any;
+    valueOf(): any;
+  }
+  type ImportValue = ExportValue | number;
+  type ModuleImports = Record<string, ImportValue>;
+  type Imports = Record<string, ModuleImports>;
+  type ExportValue = Function | Global | Memory | Table;
+  type Exports = Record<string, ExportValue>;
+  class Instance {
+    constructor(module: Module, imports?: Imports);
+    readonly exports: Exports;
+  }
+  interface MemoryDescriptor {
+    initial: number;
+    maximum?: number;
+    shared?: boolean;
+  }
+  class Memory {
+    constructor(descriptor: MemoryDescriptor);
+    readonly buffer: ArrayBuffer;
+    grow(delta: number): number;
+  }
+  type ImportExportKind = "function" | "global" | "memory" | "table";
+  interface ModuleExportDescriptor {
+    kind: ImportExportKind;
+    name: string;
+  }
+  interface ModuleImportDescriptor {
+    kind: ImportExportKind;
+    module: string;
+    name: string;
+  }
+  abstract class Module {
+    static customSections(module: Module, sectionName: string): ArrayBuffer[];
+    static exports(module: Module): ModuleExportDescriptor[];
+    static imports(module: Module): ModuleImportDescriptor[];
+  }
+  type TableKind = "anyfunc" | "externref";
+  interface TableDescriptor {
+    element: TableKind;
+    initial: number;
+    maximum?: number;
+  }
+  class Table {
+    constructor(descriptor: TableDescriptor, value?: any);
+    readonly length: number;
+    get(index: number): any;
+    grow(delta: number, value?: any): number;
+    set(index: number, value?: any): void;
+  }
+  function instantiate(module: Module, imports?: Imports): Promise<Instance>;
+  function validate(bytes: BufferSource): boolean;
 }
 /**
  * This ServiceWorker API interface represents the global execution context of a service worker.
@@ -202,92 +216,110 @@ declare namespace WebAssembly {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope)
  */
 interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
-    DOMException: typeof DOMException;
-    WorkerGlobalScope: typeof WorkerGlobalScope;
-    btoa(data: string): string;
-    atob(data: string): string;
-    setTimeout(callback: (...args: any[]) => void, msDelay?: number): number;
-    setTimeout<Args extends any[]>(callback: (...args: Args) => void, msDelay?: number, ...args: Args): number;
-    clearTimeout(timeoutId: number | null): void;
-    setInterval(callback: (...args: any[]) => void, msDelay?: number): number;
-    setInterval<Args extends any[]>(callback: (...args: Args) => void, msDelay?: number, ...args: Args): number;
-    clearInterval(timeoutId: number | null): void;
-    queueMicrotask(task: Function): void;
-    structuredClone<T>(value: T, options?: StructuredSerializeOptions): T;
-    reportError(error: any): void;
-    fetch(input: RequestInfo | URL, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
-    self: ServiceWorkerGlobalScope;
-    crypto: Crypto;
-    caches: CacheStorage;
-    scheduler: Scheduler;
-    performance: Performance;
-    Cloudflare: Cloudflare;
-    readonly origin: string;
-    Event: typeof Event;
-    ExtendableEvent: typeof ExtendableEvent;
-    CustomEvent: typeof CustomEvent;
-    PromiseRejectionEvent: typeof PromiseRejectionEvent;
-    FetchEvent: typeof FetchEvent;
-    TailEvent: typeof TailEvent;
-    TraceEvent: typeof TailEvent;
-    ScheduledEvent: typeof ScheduledEvent;
-    MessageEvent: typeof MessageEvent;
-    CloseEvent: typeof CloseEvent;
-    ReadableStreamDefaultReader: typeof ReadableStreamDefaultReader;
-    ReadableStreamBYOBReader: typeof ReadableStreamBYOBReader;
-    ReadableStream: typeof ReadableStream;
-    WritableStream: typeof WritableStream;
-    WritableStreamDefaultWriter: typeof WritableStreamDefaultWriter;
-    TransformStream: typeof TransformStream;
-    ByteLengthQueuingStrategy: typeof ByteLengthQueuingStrategy;
-    CountQueuingStrategy: typeof CountQueuingStrategy;
-    ErrorEvent: typeof ErrorEvent;
-    EventSource: typeof EventSource;
-    ReadableStreamBYOBRequest: typeof ReadableStreamBYOBRequest;
-    ReadableStreamDefaultController: typeof ReadableStreamDefaultController;
-    ReadableByteStreamController: typeof ReadableByteStreamController;
-    WritableStreamDefaultController: typeof WritableStreamDefaultController;
-    TransformStreamDefaultController: typeof TransformStreamDefaultController;
-    CompressionStream: typeof CompressionStream;
-    DecompressionStream: typeof DecompressionStream;
-    TextEncoderStream: typeof TextEncoderStream;
-    TextDecoderStream: typeof TextDecoderStream;
-    Headers: typeof Headers;
-    Body: typeof Body;
-    Request: typeof Request;
-    Response: typeof Response;
-    WebSocket: typeof WebSocket;
-    WebSocketPair: typeof WebSocketPair;
-    WebSocketRequestResponsePair: typeof WebSocketRequestResponsePair;
-    AbortController: typeof AbortController;
-    AbortSignal: typeof AbortSignal;
-    TextDecoder: typeof TextDecoder;
-    TextEncoder: typeof TextEncoder;
-    navigator: Navigator;
-    Navigator: typeof Navigator;
-    URL: typeof URL;
-    URLSearchParams: typeof URLSearchParams;
-    URLPattern: typeof URLPattern;
-    Blob: typeof Blob;
-    File: typeof File;
-    FormData: typeof FormData;
-    Crypto: typeof Crypto;
-    SubtleCrypto: typeof SubtleCrypto;
-    CryptoKey: typeof CryptoKey;
-    CacheStorage: typeof CacheStorage;
-    Cache: typeof Cache;
-    FixedLengthStream: typeof FixedLengthStream;
-    IdentityTransformStream: typeof IdentityTransformStream;
-    HTMLRewriter: typeof HTMLRewriter;
+  DOMException: typeof DOMException;
+  WorkerGlobalScope: typeof WorkerGlobalScope;
+  btoa(data: string): string;
+  atob(data: string): string;
+  setTimeout(callback: (...args: any[]) => void, msDelay?: number): number;
+  setTimeout<Args extends any[]>(
+    callback: (...args: Args) => void,
+    msDelay?: number,
+    ...args: Args
+  ): number;
+  clearTimeout(timeoutId: number | null): void;
+  setInterval(callback: (...args: any[]) => void, msDelay?: number): number;
+  setInterval<Args extends any[]>(
+    callback: (...args: Args) => void,
+    msDelay?: number,
+    ...args: Args
+  ): number;
+  clearInterval(timeoutId: number | null): void;
+  queueMicrotask(task: Function): void;
+  structuredClone<T>(value: T, options?: StructuredSerializeOptions): T;
+  reportError(error: any): void;
+  fetch(input: RequestInfo | URL, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
+  self: ServiceWorkerGlobalScope;
+  crypto: Crypto;
+  caches: CacheStorage;
+  scheduler: Scheduler;
+  performance: Performance;
+  Cloudflare: Cloudflare;
+  readonly origin: string;
+  Event: typeof Event;
+  ExtendableEvent: typeof ExtendableEvent;
+  CustomEvent: typeof CustomEvent;
+  PromiseRejectionEvent: typeof PromiseRejectionEvent;
+  FetchEvent: typeof FetchEvent;
+  TailEvent: typeof TailEvent;
+  TraceEvent: typeof TailEvent;
+  ScheduledEvent: typeof ScheduledEvent;
+  MessageEvent: typeof MessageEvent;
+  CloseEvent: typeof CloseEvent;
+  ReadableStreamDefaultReader: typeof ReadableStreamDefaultReader;
+  ReadableStreamBYOBReader: typeof ReadableStreamBYOBReader;
+  ReadableStream: typeof ReadableStream;
+  WritableStream: typeof WritableStream;
+  WritableStreamDefaultWriter: typeof WritableStreamDefaultWriter;
+  TransformStream: typeof TransformStream;
+  ByteLengthQueuingStrategy: typeof ByteLengthQueuingStrategy;
+  CountQueuingStrategy: typeof CountQueuingStrategy;
+  ErrorEvent: typeof ErrorEvent;
+  EventSource: typeof EventSource;
+  ReadableStreamBYOBRequest: typeof ReadableStreamBYOBRequest;
+  ReadableStreamDefaultController: typeof ReadableStreamDefaultController;
+  ReadableByteStreamController: typeof ReadableByteStreamController;
+  WritableStreamDefaultController: typeof WritableStreamDefaultController;
+  TransformStreamDefaultController: typeof TransformStreamDefaultController;
+  CompressionStream: typeof CompressionStream;
+  DecompressionStream: typeof DecompressionStream;
+  TextEncoderStream: typeof TextEncoderStream;
+  TextDecoderStream: typeof TextDecoderStream;
+  Headers: typeof Headers;
+  Body: typeof Body;
+  Request: typeof Request;
+  Response: typeof Response;
+  WebSocket: typeof WebSocket;
+  WebSocketPair: typeof WebSocketPair;
+  WebSocketRequestResponsePair: typeof WebSocketRequestResponsePair;
+  AbortController: typeof AbortController;
+  AbortSignal: typeof AbortSignal;
+  TextDecoder: typeof TextDecoder;
+  TextEncoder: typeof TextEncoder;
+  navigator: Navigator;
+  Navigator: typeof Navigator;
+  URL: typeof URL;
+  URLSearchParams: typeof URLSearchParams;
+  URLPattern: typeof URLPattern;
+  Blob: typeof Blob;
+  File: typeof File;
+  FormData: typeof FormData;
+  Crypto: typeof Crypto;
+  SubtleCrypto: typeof SubtleCrypto;
+  CryptoKey: typeof CryptoKey;
+  CacheStorage: typeof CacheStorage;
+  Cache: typeof Cache;
+  FixedLengthStream: typeof FixedLengthStream;
+  IdentityTransformStream: typeof IdentityTransformStream;
+  HTMLRewriter: typeof HTMLRewriter;
 }
-declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: EventListenerOrEventListenerObject<WorkerGlobalScopeEventMap[Type]>, options?: EventTargetAddEventListenerOptions | boolean): void;
-declare function removeEventListener<Type extends keyof WorkerGlobalScopeEventMap>(type: Type, handler: EventListenerOrEventListenerObject<WorkerGlobalScopeEventMap[Type]>, options?: EventTargetEventListenerOptions | boolean): void;
+declare function addEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
+  type: Type,
+  handler: EventListenerOrEventListenerObject<WorkerGlobalScopeEventMap[Type]>,
+  options?: EventTargetAddEventListenerOptions | boolean,
+): void;
+declare function removeEventListener<Type extends keyof WorkerGlobalScopeEventMap>(
+  type: Type,
+  handler: EventListenerOrEventListenerObject<WorkerGlobalScopeEventMap[Type]>,
+  options?: EventTargetEventListenerOptions | boolean,
+): void;
 /**
  * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
  */
-declare function dispatchEvent(event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap]): boolean;
+declare function dispatchEvent(
+  event: WorkerGlobalScopeEventMap[keyof WorkerGlobalScopeEventMap],
+): boolean;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/btoa) */
 declare function btoa(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/atob) */
@@ -295,13 +327,21 @@ declare function atob(data: string): string;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setTimeout) */
 declare function setTimeout(callback: (...args: any[]) => void, msDelay?: number): number;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setTimeout) */
-declare function setTimeout<Args extends any[]>(callback: (...args: Args) => void, msDelay?: number, ...args: Args): number;
+declare function setTimeout<Args extends any[]>(
+  callback: (...args: Args) => void,
+  msDelay?: number,
+  ...args: Args
+): number;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/clearTimeout) */
 declare function clearTimeout(timeoutId: number | null): void;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setInterval) */
 declare function setInterval(callback: (...args: any[]) => void, msDelay?: number): number;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/setInterval) */
-declare function setInterval<Args extends any[]>(callback: (...args: Args) => void, msDelay?: number, ...args: Args): number;
+declare function setInterval<Args extends any[]>(
+  callback: (...args: Args) => void,
+  msDelay?: number,
+  ...args: Args
+): number;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/clearInterval) */
 declare function clearInterval(timeoutId: number | null): void;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/queueMicrotask) */
@@ -311,203 +351,267 @@ declare function structuredClone<T>(value: T, options?: StructuredSerializeOptio
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/reportError) */
 declare function reportError(error: any): void;
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/fetch) */
-declare function fetch(input: RequestInfo | URL, init?: RequestInit<RequestInitCfProperties>): Promise<Response>;
+declare function fetch(
+  input: RequestInfo | URL,
+  init?: RequestInit<RequestInitCfProperties>,
+): Promise<Response>;
 declare const self: ServiceWorkerGlobalScope;
 /**
-* The Web Crypto API provides a set of low-level functions for common cryptographic tasks.
-* The Workers runtime implements the full surface of this API, but with some differences in
-* the [supported algorithms](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#supported-algorithms)
-* compared to those implemented in most browsers.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
-*/
+ * The Web Crypto API provides a set of low-level functions for common cryptographic tasks.
+ * The Workers runtime implements the full surface of this API, but with some differences in
+ * the [supported algorithms](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#supported-algorithms)
+ * compared to those implemented in most browsers.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
+ */
 declare const crypto: Crypto;
 /**
-* The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
-*/
+ * The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
+ */
 declare const caches: CacheStorage;
 declare const scheduler: Scheduler;
 /**
-* The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
-* as well as timing of subrequests and other operations.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
-*/
+ * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+ * as well as timing of subrequests and other operations.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+ */
 declare const performance: Performance;
 declare const Cloudflare: Cloudflare;
 declare const origin: string;
 declare const navigator: Navigator;
-interface TestController {
-}
+interface TestController {}
 interface ExecutionContext<Props = unknown> {
-    waitUntil(promise: Promise<any>): void;
-    passThroughOnException(): void;
-    readonly props: Props;
+  waitUntil(promise: Promise<any>): void;
+  passThroughOnException(): void;
+  readonly props: Props;
 }
-type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>, env: Env, ctx: ExecutionContext) => Response | Promise<Response>;
-type ExportedHandlerTailHandler<Env = unknown> = (events: TraceItem[], env: Env, ctx: ExecutionContext) => void | Promise<void>;
-type ExportedHandlerTraceHandler<Env = unknown> = (traces: TraceItem[], env: Env, ctx: ExecutionContext) => void | Promise<void>;
-type ExportedHandlerTailStreamHandler<Env = unknown> = (event: TailStream.TailEvent<TailStream.Onset>, env: Env, ctx: ExecutionContext) => TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>;
-type ExportedHandlerScheduledHandler<Env = unknown> = (controller: ScheduledController, env: Env, ctx: ExecutionContext) => void | Promise<void>;
-type ExportedHandlerQueueHandler<Env = unknown, Message = unknown> = (batch: MessageBatch<Message>, env: Env, ctx: ExecutionContext) => void | Promise<void>;
-type ExportedHandlerTestHandler<Env = unknown> = (controller: TestController, env: Env, ctx: ExecutionContext) => void | Promise<void>;
+type ExportedHandlerFetchHandler<Env = unknown, CfHostMetadata = unknown> = (
+  request: Request<CfHostMetadata, IncomingRequestCfProperties<CfHostMetadata>>,
+  env: Env,
+  ctx: ExecutionContext,
+) => Response | Promise<Response>;
+type ExportedHandlerTailHandler<Env = unknown> = (
+  events: TraceItem[],
+  env: Env,
+  ctx: ExecutionContext,
+) => void | Promise<void>;
+type ExportedHandlerTraceHandler<Env = unknown> = (
+  traces: TraceItem[],
+  env: Env,
+  ctx: ExecutionContext,
+) => void | Promise<void>;
+type ExportedHandlerTailStreamHandler<Env = unknown> = (
+  event: TailStream.TailEvent<TailStream.Onset>,
+  env: Env,
+  ctx: ExecutionContext,
+) => TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>;
+type ExportedHandlerScheduledHandler<Env = unknown> = (
+  controller: ScheduledController,
+  env: Env,
+  ctx: ExecutionContext,
+) => void | Promise<void>;
+type ExportedHandlerQueueHandler<Env = unknown, Message = unknown> = (
+  batch: MessageBatch<Message>,
+  env: Env,
+  ctx: ExecutionContext,
+) => void | Promise<void>;
+type ExportedHandlerTestHandler<Env = unknown> = (
+  controller: TestController,
+  env: Env,
+  ctx: ExecutionContext,
+) => void | Promise<void>;
 interface ExportedHandler<Env = unknown, QueueHandlerMessage = unknown, CfHostMetadata = unknown> {
-    fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata>;
-    tail?: ExportedHandlerTailHandler<Env>;
-    trace?: ExportedHandlerTraceHandler<Env>;
-    tailStream?: ExportedHandlerTailStreamHandler<Env>;
-    scheduled?: ExportedHandlerScheduledHandler<Env>;
-    test?: ExportedHandlerTestHandler<Env>;
-    email?: EmailExportedHandler<Env>;
-    queue?: ExportedHandlerQueueHandler<Env, QueueHandlerMessage>;
+  fetch?: ExportedHandlerFetchHandler<Env, CfHostMetadata>;
+  tail?: ExportedHandlerTailHandler<Env>;
+  trace?: ExportedHandlerTraceHandler<Env>;
+  tailStream?: ExportedHandlerTailStreamHandler<Env>;
+  scheduled?: ExportedHandlerScheduledHandler<Env>;
+  test?: ExportedHandlerTestHandler<Env>;
+  email?: EmailExportedHandler<Env>;
+  queue?: ExportedHandlerQueueHandler<Env, QueueHandlerMessage>;
 }
 interface StructuredSerializeOptions {
-    transfer?: any[];
+  transfer?: any[];
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent) */
 declare abstract class PromiseRejectionEvent extends Event {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent/promise) */
-    readonly promise: Promise<any>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent/reason) */
-    readonly reason: any;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent/promise) */
+  readonly promise: Promise<any>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent/reason) */
+  readonly reason: any;
 }
 declare abstract class Navigator {
-    sendBeacon(url: string, body?: (ReadableStream | string | (ArrayBuffer | ArrayBufferView) | Blob | FormData | URLSearchParams | URLSearchParams)): boolean;
-    readonly userAgent: string;
-    readonly hardwareConcurrency: number;
+  sendBeacon(
+    url: string,
+    body?:
+      | ReadableStream
+      | string
+      | (ArrayBuffer | ArrayBufferView)
+      | Blob
+      | FormData
+      | URLSearchParams
+      | URLSearchParams,
+  ): boolean;
+  readonly userAgent: string;
+  readonly hardwareConcurrency: number;
 }
 interface AlarmInvocationInfo {
-    readonly isRetry: boolean;
-    readonly retryCount: number;
+  readonly isRetry: boolean;
+  readonly retryCount: number;
 }
 interface Cloudflare {
-    readonly compatibilityFlags: Record<string, boolean>;
+  readonly compatibilityFlags: Record<string, boolean>;
 }
 interface DurableObject {
-    fetch(request: Request): Response | Promise<Response>;
-    alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
-    webSocketMessage?(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void>;
-    webSocketClose?(ws: WebSocket, code: number, reason: string, wasClean: boolean): void | Promise<void>;
-    webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
+  fetch(request: Request): Response | Promise<Response>;
+  alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
+  webSocketMessage?(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void>;
+  webSocketClose?(
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    wasClean: boolean,
+  ): void | Promise<void>;
+  webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
 }
-type DurableObjectStub<T extends Rpc.DurableObjectBranded | undefined = undefined> = Fetcher<T, "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError"> & {
-    readonly id: DurableObjectId;
-    readonly name?: string;
+type DurableObjectStub<T extends Rpc.DurableObjectBranded | undefined = undefined> = Fetcher<
+  T,
+  "alarm" | "webSocketMessage" | "webSocketClose" | "webSocketError"
+> & {
+  readonly id: DurableObjectId;
+  readonly name?: string;
 };
 interface DurableObjectId {
-    toString(): string;
-    equals(other: DurableObjectId): boolean;
-    readonly name?: string;
+  toString(): string;
+  equals(other: DurableObjectId): boolean;
+  readonly name?: string;
 }
-declare abstract class DurableObjectNamespace<T extends Rpc.DurableObjectBranded | undefined = undefined> {
-    newUniqueId(options?: DurableObjectNamespaceNewUniqueIdOptions): DurableObjectId;
-    idFromName(name: string): DurableObjectId;
-    idFromString(id: string): DurableObjectId;
-    get(id: DurableObjectId, options?: DurableObjectNamespaceGetDurableObjectOptions): DurableObjectStub<T>;
-    getByName(name: string, options?: DurableObjectNamespaceGetDurableObjectOptions): DurableObjectStub<T>;
-    jurisdiction(jurisdiction: DurableObjectJurisdiction): DurableObjectNamespace<T>;
+declare abstract class DurableObjectNamespace<
+  T extends Rpc.DurableObjectBranded | undefined = undefined,
+> {
+  newUniqueId(options?: DurableObjectNamespaceNewUniqueIdOptions): DurableObjectId;
+  idFromName(name: string): DurableObjectId;
+  idFromString(id: string): DurableObjectId;
+  get(
+    id: DurableObjectId,
+    options?: DurableObjectNamespaceGetDurableObjectOptions,
+  ): DurableObjectStub<T>;
+  getByName(
+    name: string,
+    options?: DurableObjectNamespaceGetDurableObjectOptions,
+  ): DurableObjectStub<T>;
+  jurisdiction(jurisdiction: DurableObjectJurisdiction): DurableObjectNamespace<T>;
 }
 type DurableObjectJurisdiction = "eu" | "fedramp" | "fedramp-high";
 interface DurableObjectNamespaceNewUniqueIdOptions {
-    jurisdiction?: DurableObjectJurisdiction;
+  jurisdiction?: DurableObjectJurisdiction;
 }
-type DurableObjectLocationHint = "wnam" | "enam" | "sam" | "weur" | "eeur" | "apac" | "oc" | "afr" | "me";
+type DurableObjectLocationHint =
+  | "wnam"
+  | "enam"
+  | "sam"
+  | "weur"
+  | "eeur"
+  | "apac"
+  | "oc"
+  | "afr"
+  | "me";
 interface DurableObjectNamespaceGetDurableObjectOptions {
-    locationHint?: DurableObjectLocationHint;
+  locationHint?: DurableObjectLocationHint;
 }
-interface DurableObjectClass<_T extends Rpc.DurableObjectBranded | undefined = undefined> {
-}
+interface DurableObjectClass<_T extends Rpc.DurableObjectBranded | undefined = undefined> {}
 interface DurableObjectState<Props = unknown> {
-    waitUntil(promise: Promise<any>): void;
-    readonly props: Props;
-    readonly id: DurableObjectId;
-    readonly storage: DurableObjectStorage;
-    container?: Container;
-    blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
-    acceptWebSocket(ws: WebSocket, tags?: string[]): void;
-    getWebSockets(tag?: string): WebSocket[];
-    setWebSocketAutoResponse(maybeReqResp?: WebSocketRequestResponsePair): void;
-    getWebSocketAutoResponse(): WebSocketRequestResponsePair | null;
-    getWebSocketAutoResponseTimestamp(ws: WebSocket): Date | null;
-    setHibernatableWebSocketEventTimeout(timeoutMs?: number): void;
-    getHibernatableWebSocketEventTimeout(): number | null;
-    getTags(ws: WebSocket): string[];
-    abort(reason?: string): void;
+  waitUntil(promise: Promise<any>): void;
+  readonly props: Props;
+  readonly id: DurableObjectId;
+  readonly storage: DurableObjectStorage;
+  container?: Container;
+  blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>;
+  acceptWebSocket(ws: WebSocket, tags?: string[]): void;
+  getWebSockets(tag?: string): WebSocket[];
+  setWebSocketAutoResponse(maybeReqResp?: WebSocketRequestResponsePair): void;
+  getWebSocketAutoResponse(): WebSocketRequestResponsePair | null;
+  getWebSocketAutoResponseTimestamp(ws: WebSocket): Date | null;
+  setHibernatableWebSocketEventTimeout(timeoutMs?: number): void;
+  getHibernatableWebSocketEventTimeout(): number | null;
+  getTags(ws: WebSocket): string[];
+  abort(reason?: string): void;
 }
 interface DurableObjectTransaction {
-    get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;
-    get<T = unknown>(keys: string[], options?: DurableObjectGetOptions): Promise<Map<string, T>>;
-    list<T = unknown>(options?: DurableObjectListOptions): Promise<Map<string, T>>;
-    put<T>(key: string, value: T, options?: DurableObjectPutOptions): Promise<void>;
-    put<T>(entries: Record<string, T>, options?: DurableObjectPutOptions): Promise<void>;
-    delete(key: string, options?: DurableObjectPutOptions): Promise<boolean>;
-    delete(keys: string[], options?: DurableObjectPutOptions): Promise<number>;
-    rollback(): void;
-    getAlarm(options?: DurableObjectGetAlarmOptions): Promise<number | null>;
-    setAlarm(scheduledTime: number | Date, options?: DurableObjectSetAlarmOptions): Promise<void>;
-    deleteAlarm(options?: DurableObjectSetAlarmOptions): Promise<void>;
+  get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;
+  get<T = unknown>(keys: string[], options?: DurableObjectGetOptions): Promise<Map<string, T>>;
+  list<T = unknown>(options?: DurableObjectListOptions): Promise<Map<string, T>>;
+  put<T>(key: string, value: T, options?: DurableObjectPutOptions): Promise<void>;
+  put<T>(entries: Record<string, T>, options?: DurableObjectPutOptions): Promise<void>;
+  delete(key: string, options?: DurableObjectPutOptions): Promise<boolean>;
+  delete(keys: string[], options?: DurableObjectPutOptions): Promise<number>;
+  rollback(): void;
+  getAlarm(options?: DurableObjectGetAlarmOptions): Promise<number | null>;
+  setAlarm(scheduledTime: number | Date, options?: DurableObjectSetAlarmOptions): Promise<void>;
+  deleteAlarm(options?: DurableObjectSetAlarmOptions): Promise<void>;
 }
 interface DurableObjectStorage {
-    get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;
-    get<T = unknown>(keys: string[], options?: DurableObjectGetOptions): Promise<Map<string, T>>;
-    list<T = unknown>(options?: DurableObjectListOptions): Promise<Map<string, T>>;
-    put<T>(key: string, value: T, options?: DurableObjectPutOptions): Promise<void>;
-    put<T>(entries: Record<string, T>, options?: DurableObjectPutOptions): Promise<void>;
-    delete(key: string, options?: DurableObjectPutOptions): Promise<boolean>;
-    delete(keys: string[], options?: DurableObjectPutOptions): Promise<number>;
-    deleteAll(options?: DurableObjectPutOptions): Promise<void>;
-    transaction<T>(closure: (txn: DurableObjectTransaction) => Promise<T>): Promise<T>;
-    getAlarm(options?: DurableObjectGetAlarmOptions): Promise<number | null>;
-    setAlarm(scheduledTime: number | Date, options?: DurableObjectSetAlarmOptions): Promise<void>;
-    deleteAlarm(options?: DurableObjectSetAlarmOptions): Promise<void>;
-    sync(): Promise<void>;
-    sql: SqlStorage;
-    kv: SyncKvStorage;
-    transactionSync<T>(closure: () => T): T;
-    getCurrentBookmark(): Promise<string>;
-    getBookmarkForTime(timestamp: number | Date): Promise<string>;
-    onNextSessionRestoreBookmark(bookmark: string): Promise<string>;
+  get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T | undefined>;
+  get<T = unknown>(keys: string[], options?: DurableObjectGetOptions): Promise<Map<string, T>>;
+  list<T = unknown>(options?: DurableObjectListOptions): Promise<Map<string, T>>;
+  put<T>(key: string, value: T, options?: DurableObjectPutOptions): Promise<void>;
+  put<T>(entries: Record<string, T>, options?: DurableObjectPutOptions): Promise<void>;
+  delete(key: string, options?: DurableObjectPutOptions): Promise<boolean>;
+  delete(keys: string[], options?: DurableObjectPutOptions): Promise<number>;
+  deleteAll(options?: DurableObjectPutOptions): Promise<void>;
+  transaction<T>(closure: (txn: DurableObjectTransaction) => Promise<T>): Promise<T>;
+  getAlarm(options?: DurableObjectGetAlarmOptions): Promise<number | null>;
+  setAlarm(scheduledTime: number | Date, options?: DurableObjectSetAlarmOptions): Promise<void>;
+  deleteAlarm(options?: DurableObjectSetAlarmOptions): Promise<void>;
+  sync(): Promise<void>;
+  sql: SqlStorage;
+  kv: SyncKvStorage;
+  transactionSync<T>(closure: () => T): T;
+  getCurrentBookmark(): Promise<string>;
+  getBookmarkForTime(timestamp: number | Date): Promise<string>;
+  onNextSessionRestoreBookmark(bookmark: string): Promise<string>;
 }
 interface DurableObjectListOptions {
-    start?: string;
-    startAfter?: string;
-    end?: string;
-    prefix?: string;
-    reverse?: boolean;
-    limit?: number;
-    allowConcurrency?: boolean;
-    noCache?: boolean;
+  start?: string;
+  startAfter?: string;
+  end?: string;
+  prefix?: string;
+  reverse?: boolean;
+  limit?: number;
+  allowConcurrency?: boolean;
+  noCache?: boolean;
 }
 interface DurableObjectGetOptions {
-    allowConcurrency?: boolean;
-    noCache?: boolean;
+  allowConcurrency?: boolean;
+  noCache?: boolean;
 }
 interface DurableObjectGetAlarmOptions {
-    allowConcurrency?: boolean;
+  allowConcurrency?: boolean;
 }
 interface DurableObjectPutOptions {
-    allowConcurrency?: boolean;
-    allowUnconfirmed?: boolean;
-    noCache?: boolean;
+  allowConcurrency?: boolean;
+  allowUnconfirmed?: boolean;
+  noCache?: boolean;
 }
 interface DurableObjectSetAlarmOptions {
-    allowConcurrency?: boolean;
-    allowUnconfirmed?: boolean;
+  allowConcurrency?: boolean;
+  allowUnconfirmed?: boolean;
 }
 declare class WebSocketRequestResponsePair {
-    constructor(request: string, response: string);
-    get request(): string;
-    get response(): string;
+  constructor(request: string, response: string);
+  get request(): string;
+  get response(): string;
 }
 interface AnalyticsEngineDataset {
-    writeDataPoint(event?: AnalyticsEngineDataPoint): void;
+  writeDataPoint(event?: AnalyticsEngineDataPoint): void;
 }
 interface AnalyticsEngineDataPoint {
-    indexes?: ((ArrayBuffer | string) | null)[];
-    doubles?: number[];
-    blobs?: ((ArrayBuffer | string) | null)[];
+  indexes?: ((ArrayBuffer | string) | null)[];
+  doubles?: number[];
+  blobs?: ((ArrayBuffer | string) | null)[];
 }
 /**
  * An event which takes place in the DOM.
@@ -515,179 +619,189 @@ interface AnalyticsEngineDataPoint {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
 declare class Event {
-    constructor(type: string, init?: EventInit);
-    /**
-     * Returns the type of event, e.g. "click", "hashchange", or "submit".
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/type)
-     */
-    get type(): string;
-    /**
-     * Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET, and BUBBLING_PHASE.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/eventPhase)
-     */
-    get eventPhase(): number;
-    /**
-     * Returns true or false depending on how event was initialized. True if event invokes listeners past a ShadowRoot node that is the root of its target, and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/composed)
-     */
-    get composed(): boolean;
-    /**
-     * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/bubbles)
-     */
-    get bubbles(): boolean;
-    /**
-     * Returns true or false depending on how event was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which event was dispatched, can be canceled by invoking the preventDefault() method.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/cancelable)
-     */
-    get cancelable(): boolean;
-    /**
-     * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/defaultPrevented)
-     */
-    get defaultPrevented(): boolean;
-    /**
-     * @deprecated
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/returnValue)
-     */
-    get returnValue(): boolean;
-    /**
-     * Returns the object whose event listener's callback is currently being invoked.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
-     */
-    get currentTarget(): EventTarget | undefined;
-    /**
-     * Returns the object to which event is dispatched (its target).
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
-     */
-    get target(): EventTarget | undefined;
-    /**
-     * @deprecated
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)
-     */
-    get srcElement(): EventTarget | undefined;
-    /**
-     * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/timeStamp)
-     */
-    get timeStamp(): number;
-    /**
-     * Returns true if event was dispatched by the user agent, and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/isTrusted)
-     */
-    get isTrusted(): boolean;
-    /**
-     * @deprecated
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/cancelBubble)
-     */
-    get cancelBubble(): boolean;
-    /**
-     * @deprecated
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/cancelBubble)
-     */
-    set cancelBubble(value: boolean);
-    /**
-     * Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/stopImmediatePropagation)
-     */
-    stopImmediatePropagation(): void;
-    /**
-     * If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/preventDefault)
-     */
-    preventDefault(): void;
-    /**
-     * When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/stopPropagation)
-     */
-    stopPropagation(): void;
-    /**
-     * Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/composedPath)
-     */
-    composedPath(): EventTarget[];
-    static readonly NONE: number;
-    static readonly CAPTURING_PHASE: number;
-    static readonly AT_TARGET: number;
-    static readonly BUBBLING_PHASE: number;
+  constructor(type: string, init?: EventInit);
+  /**
+   * Returns the type of event, e.g. "click", "hashchange", or "submit".
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/type)
+   */
+  get type(): string;
+  /**
+   * Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET, and BUBBLING_PHASE.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/eventPhase)
+   */
+  get eventPhase(): number;
+  /**
+   * Returns true or false depending on how event was initialized. True if event invokes listeners past a ShadowRoot node that is the root of its target, and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/composed)
+   */
+  get composed(): boolean;
+  /**
+   * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/bubbles)
+   */
+  get bubbles(): boolean;
+  /**
+   * Returns true or false depending on how event was initialized. Its return value does not always carry meaning, but true can indicate that part of the operation during which event was dispatched, can be canceled by invoking the preventDefault() method.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/cancelable)
+   */
+  get cancelable(): boolean;
+  /**
+   * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/defaultPrevented)
+   */
+  get defaultPrevented(): boolean;
+  /**
+   * @deprecated
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/returnValue)
+   */
+  get returnValue(): boolean;
+  /**
+   * Returns the object whose event listener's callback is currently being invoked.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
+   */
+  get currentTarget(): EventTarget | undefined;
+  /**
+   * Returns the object to which event is dispatched (its target).
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
+   */
+  get target(): EventTarget | undefined;
+  /**
+   * @deprecated
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/srcElement)
+   */
+  get srcElement(): EventTarget | undefined;
+  /**
+   * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/timeStamp)
+   */
+  get timeStamp(): number;
+  /**
+   * Returns true if event was dispatched by the user agent, and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/isTrusted)
+   */
+  get isTrusted(): boolean;
+  /**
+   * @deprecated
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/cancelBubble)
+   */
+  get cancelBubble(): boolean;
+  /**
+   * @deprecated
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/cancelBubble)
+   */
+  set cancelBubble(value: boolean);
+  /**
+   * Invoking this method prevents event from reaching any registered event listeners after the current one finishes running and, when dispatched in a tree, also prevents event from reaching any other objects.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/stopImmediatePropagation)
+   */
+  stopImmediatePropagation(): void;
+  /**
+   * If invoked when the cancelable attribute value is true, and while executing a listener for the event with passive set to false, signals to the operation that caused event to be dispatched that it needs to be canceled.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/preventDefault)
+   */
+  preventDefault(): void;
+  /**
+   * When dispatched in a tree, invoking this method prevents event from reaching any objects other than the current object.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/stopPropagation)
+   */
+  stopPropagation(): void;
+  /**
+   * Returns the invocation target objects of event's path (objects on which listeners will be invoked), except for any nodes in shadow trees of which the shadow root's mode is "closed" that are not reachable from event's currentTarget.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/composedPath)
+   */
+  composedPath(): EventTarget[];
+  static readonly NONE: number;
+  static readonly CAPTURING_PHASE: number;
+  static readonly AT_TARGET: number;
+  static readonly BUBBLING_PHASE: number;
 }
 interface EventInit {
-    bubbles?: boolean;
-    cancelable?: boolean;
-    composed?: boolean;
+  bubbles?: boolean;
+  cancelable?: boolean;
+  composed?: boolean;
 }
 type EventListener<EventType extends Event = Event> = (event: EventType) => void;
 interface EventListenerObject<EventType extends Event = Event> {
-    handleEvent(event: EventType): void;
+  handleEvent(event: EventType): void;
 }
-type EventListenerOrEventListenerObject<EventType extends Event = Event> = EventListener<EventType> | EventListenerObject<EventType>;
+type EventListenerOrEventListenerObject<EventType extends Event = Event> =
+  | EventListener<EventType>
+  | EventListenerObject<EventType>;
 /**
  * EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
  */
 declare class EventTarget<EventMap extends Record<string, Event> = Record<string, Event>> {
-    constructor();
-    /**
-     * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
-     *
-     * The options argument sets listener-specific options. For compatibility this can be a boolean, in which case the method behaves exactly as if the value was specified as options's capture.
-     *
-     * When set to true, options's capture prevents callback from being invoked when the event's eventPhase attribute value is BUBBLING_PHASE. When false (or not present), callback will not be invoked when event's eventPhase attribute value is CAPTURING_PHASE. Either way, callback will be invoked if event's eventPhase attribute value is AT_TARGET.
-     *
-     * When set to true, options's passive indicates that the callback will not cancel the event by invoking preventDefault(). This is used to enable performance optimizations described in § 2.8 Observing event listeners.
-     *
-     * When set to true, options's once indicates that the callback will only be invoked once after which the event listener will be removed.
-     *
-     * If an AbortSignal is passed for options's signal, then the event listener will be removed when signal is aborted.
-     *
-     * The event listener is appended to target's event listener list and is not appended if it has the same type, callback, and capture.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
-     */
-    addEventListener<Type extends keyof EventMap>(type: Type, handler: EventListenerOrEventListenerObject<EventMap[Type]>, options?: EventTargetAddEventListenerOptions | boolean): void;
-    /**
-     * Removes the event listener in target's event listener list with the same type, callback, and options.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
-     */
-    removeEventListener<Type extends keyof EventMap>(type: Type, handler: EventListenerOrEventListenerObject<EventMap[Type]>, options?: EventTargetEventListenerOptions | boolean): void;
-    /**
-     * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
-     */
-    dispatchEvent(event: EventMap[keyof EventMap]): boolean;
+  constructor();
+  /**
+   * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
+   *
+   * The options argument sets listener-specific options. For compatibility this can be a boolean, in which case the method behaves exactly as if the value was specified as options's capture.
+   *
+   * When set to true, options's capture prevents callback from being invoked when the event's eventPhase attribute value is BUBBLING_PHASE. When false (or not present), callback will not be invoked when event's eventPhase attribute value is CAPTURING_PHASE. Either way, callback will be invoked if event's eventPhase attribute value is AT_TARGET.
+   *
+   * When set to true, options's passive indicates that the callback will not cancel the event by invoking preventDefault(). This is used to enable performance optimizations described in § 2.8 Observing event listeners.
+   *
+   * When set to true, options's once indicates that the callback will only be invoked once after which the event listener will be removed.
+   *
+   * If an AbortSignal is passed for options's signal, then the event listener will be removed when signal is aborted.
+   *
+   * The event listener is appended to target's event listener list and is not appended if it has the same type, callback, and capture.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
+   */
+  addEventListener<Type extends keyof EventMap>(
+    type: Type,
+    handler: EventListenerOrEventListenerObject<EventMap[Type]>,
+    options?: EventTargetAddEventListenerOptions | boolean,
+  ): void;
+  /**
+   * Removes the event listener in target's event listener list with the same type, callback, and options.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
+   */
+  removeEventListener<Type extends keyof EventMap>(
+    type: Type,
+    handler: EventListenerOrEventListenerObject<EventMap[Type]>,
+    options?: EventTargetEventListenerOptions | boolean,
+  ): void;
+  /**
+   * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
+   */
+  dispatchEvent(event: EventMap[keyof EventMap]): boolean;
 }
 interface EventTargetEventListenerOptions {
-    capture?: boolean;
+  capture?: boolean;
 }
 interface EventTargetAddEventListenerOptions {
-    capture?: boolean;
-    passive?: boolean;
-    once?: boolean;
-    signal?: AbortSignal;
+  capture?: boolean;
+  passive?: boolean;
+  once?: boolean;
+  signal?: AbortSignal;
 }
 interface EventTargetHandlerObject {
-    handleEvent: (event: Event) => any | undefined;
+  handleEvent: (event: Event) => any | undefined;
 }
 /**
  * A controller object that allows you to abort one or more DOM requests as and when desired.
@@ -695,19 +809,19 @@ interface EventTargetHandlerObject {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortController)
  */
 declare class AbortController {
-    constructor();
-    /**
-     * Returns the AbortSignal object associated with this object.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortController/signal)
-     */
-    get signal(): AbortSignal;
-    /**
-     * Invoking this method will set this object's AbortSignal's aborted flag and signal to any observers that the associated activity is to be aborted.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortController/abort)
-     */
-    abort(reason?: any): void;
+  constructor();
+  /**
+   * Returns the AbortSignal object associated with this object.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortController/signal)
+   */
+  get signal(): AbortSignal;
+  /**
+   * Invoking this method will set this object's AbortSignal's aborted flag and signal to any observers that the associated activity is to be aborted.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortController/abort)
+   */
+  abort(reason?: any): void;
 }
 /**
  * A signal object that allows you to communicate with a DOM request (such as a Fetch) and abort it if required via an AbortController object.
@@ -715,32 +829,32 @@ declare class AbortController {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal)
  */
 declare abstract class AbortSignal extends EventTarget {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static) */
-    static abort(reason?: any): AbortSignal;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static) */
-    static timeout(delay: number): AbortSignal;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    static any(signals: AbortSignal[]): AbortSignal;
-    /**
-     * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/aborted)
-     */
-    get aborted(): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/reason) */
-    get reason(): any;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_event) */
-    get onabort(): any | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_event) */
-    set onabort(value: any | null);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/throwIfAborted) */
-    throwIfAborted(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static) */
+  static abort(reason?: any): AbortSignal;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static) */
+  static timeout(delay: number): AbortSignal;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
+  static any(signals: AbortSignal[]): AbortSignal;
+  /**
+   * Returns true if this AbortSignal's AbortController has signaled to abort, and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/aborted)
+   */
+  get aborted(): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/reason) */
+  get reason(): any;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_event) */
+  get onabort(): any | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_event) */
+  set onabort(value: any | null);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/throwIfAborted) */
+  throwIfAborted(): void;
 }
 interface Scheduler {
-    wait(delay: number, maybeOptions?: SchedulerWaitOptions): Promise<void>;
+  wait(delay: number, maybeOptions?: SchedulerWaitOptions): Promise<void>;
 }
 interface SchedulerWaitOptions {
-    signal?: AbortSignal;
+  signal?: AbortSignal;
 }
 /**
  * Extends the lifetime of the install and activate events dispatched on the global scope as part of the service worker lifecycle. This ensures that any functional events (like FetchEvent) are not dispatched until it upgrades database schemas and deletes the outdated cache entries.
@@ -748,24 +862,24 @@ interface SchedulerWaitOptions {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ExtendableEvent)
  */
 declare abstract class ExtendableEvent extends Event {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ExtendableEvent/waitUntil) */
-    waitUntil(promise: Promise<any>): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ExtendableEvent/waitUntil) */
+  waitUntil(promise: Promise<any>): void;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CustomEvent) */
 declare class CustomEvent<T = any> extends Event {
-    constructor(type: string, init?: CustomEventCustomEventInit);
-    /**
-     * Returns any custom data event was created with. Typically used for synthetic events.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CustomEvent/detail)
-     */
-    get detail(): T;
+  constructor(type: string, init?: CustomEventCustomEventInit);
+  /**
+   * Returns any custom data event was created with. Typically used for synthetic events.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CustomEvent/detail)
+   */
+  get detail(): T;
 }
 interface CustomEventCustomEventInit {
-    bubbles?: boolean;
-    cancelable?: boolean;
-    composed?: boolean;
-    detail?: any;
+  bubbles?: boolean;
+  cancelable?: boolean;
+  composed?: boolean;
+  detail?: any;
 }
 /**
  * A file-like object of immutable, raw data. Blobs represent data that isn't necessarily in a JavaScript-native format. The File interface is based on Blob, inheriting blob functionality and expanding it to support files on the user's system.
@@ -773,24 +887,24 @@ interface CustomEventCustomEventInit {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob)
  */
 declare class Blob {
-    constructor(type?: ((ArrayBuffer | ArrayBufferView) | string | Blob)[], options?: BlobOptions);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/size) */
-    get size(): number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/type) */
-    get type(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/slice) */
-    slice(start?: number, end?: number, type?: string): Blob;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer) */
-    arrayBuffer(): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/bytes) */
-    bytes(): Promise<Uint8Array>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/text) */
-    text(): Promise<string>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/stream) */
-    stream(): ReadableStream;
+  constructor(type?: ((ArrayBuffer | ArrayBufferView) | string | Blob)[], options?: BlobOptions);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/size) */
+  get size(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/type) */
+  get type(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/slice) */
+  slice(start?: number, end?: number, type?: string): Blob;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer) */
+  arrayBuffer(): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/bytes) */
+  bytes(): Promise<Uint8Array>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/text) */
+  text(): Promise<string>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Blob/stream) */
+  stream(): ReadableStream;
 }
 interface BlobOptions {
-    type?: string;
+  type?: string;
 }
 /**
  * Provides information about files and allows JavaScript in a web page to access their content.
@@ -798,66 +912,80 @@ interface BlobOptions {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/File)
  */
 declare class File extends Blob {
-    constructor(bits: ((ArrayBuffer | ArrayBufferView) | string | Blob)[] | undefined, name: string, options?: FileOptions);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/File/name) */
-    get name(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/File/lastModified) */
-    get lastModified(): number;
+  constructor(
+    bits: ((ArrayBuffer | ArrayBufferView) | string | Blob)[] | undefined,
+    name: string,
+    options?: FileOptions,
+  );
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/File/name) */
+  get name(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/File/lastModified) */
+  get lastModified(): number;
 }
 interface FileOptions {
-    type?: string;
-    lastModified?: number;
+  type?: string;
+  lastModified?: number;
 }
 /**
-* The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
-*/
+ * The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
+ */
 declare abstract class CacheStorage {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CacheStorage/open) */
-    open(cacheName: string): Promise<Cache>;
-    readonly default: Cache;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CacheStorage/open) */
+  open(cacheName: string): Promise<Cache>;
+  readonly default: Cache;
 }
 /**
-* The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
-*/
+ * The Cache API allows fine grained control of reading and writing from the Cloudflare global network cache.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/)
+ */
 declare abstract class Cache {
-    /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#delete) */
-    delete(request: RequestInfo | URL, options?: CacheQueryOptions): Promise<boolean>;
-    /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#match) */
-    match(request: RequestInfo | URL, options?: CacheQueryOptions): Promise<Response | undefined>;
-    /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#put) */
-    put(request: RequestInfo | URL, response: Response): Promise<void>;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#delete) */
+  delete(request: RequestInfo | URL, options?: CacheQueryOptions): Promise<boolean>;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#match) */
+  match(request: RequestInfo | URL, options?: CacheQueryOptions): Promise<Response | undefined>;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/cache/#put) */
+  put(request: RequestInfo | URL, response: Response): Promise<void>;
 }
 interface CacheQueryOptions {
-    ignoreMethod?: boolean;
+  ignoreMethod?: boolean;
 }
 /**
-* The Web Crypto API provides a set of low-level functions for common cryptographic tasks.
-* The Workers runtime implements the full surface of this API, but with some differences in
-* the [supported algorithms](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#supported-algorithms)
-* compared to those implemented in most browsers.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
-*/
+ * The Web Crypto API provides a set of low-level functions for common cryptographic tasks.
+ * The Workers runtime implements the full surface of this API, but with some differences in
+ * the [supported algorithms](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#supported-algorithms)
+ * compared to those implemented in most browsers.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
+ */
 declare abstract class Crypto {
-    /**
-     * Available only in secure contexts.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/subtle)
-     */
-    get subtle(): SubtleCrypto;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/getRandomValues) */
-    getRandomValues<T extends Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array>(buffer: T): T;
-    /**
-     * Available only in secure contexts.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
-     */
-    randomUUID(): string;
-    DigestStream: typeof DigestStream;
+  /**
+   * Available only in secure contexts.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/subtle)
+   */
+  get subtle(): SubtleCrypto;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/getRandomValues) */
+  getRandomValues<
+    T extends
+      | Int8Array
+      | Uint8Array
+      | Int16Array
+      | Uint16Array
+      | Int32Array
+      | Uint32Array
+      | BigInt64Array
+      | BigUint64Array,
+  >(buffer: T): T;
+  /**
+   * Available only in secure contexts.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
+   */
+  randomUUID(): string;
+  DigestStream: typeof DigestStream;
 }
 /**
  * This Web Crypto API interface provides a number of low-level cryptographic functions. It is accessed via the Crypto.subtle properties available in a window context (via Window.crypto).
@@ -866,31 +994,84 @@ declare abstract class Crypto {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto)
  */
 declare abstract class SubtleCrypto {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt) */
-    encrypt(algorithm: string | SubtleCryptoEncryptAlgorithm, key: CryptoKey, plainText: ArrayBuffer | ArrayBufferView): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt) */
-    decrypt(algorithm: string | SubtleCryptoEncryptAlgorithm, key: CryptoKey, cipherText: ArrayBuffer | ArrayBufferView): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) */
-    sign(algorithm: string | SubtleCryptoSignAlgorithm, key: CryptoKey, data: ArrayBuffer | ArrayBufferView): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) */
-    verify(algorithm: string | SubtleCryptoSignAlgorithm, key: CryptoKey, signature: ArrayBuffer | ArrayBufferView, data: ArrayBuffer | ArrayBufferView): Promise<boolean>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/digest) */
-    digest(algorithm: string | SubtleCryptoHashAlgorithm, data: ArrayBuffer | ArrayBufferView): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey) */
-    generateKey(algorithm: string | SubtleCryptoGenerateKeyAlgorithm, extractable: boolean, keyUsages: string[]): Promise<CryptoKey | CryptoKeyPair>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey) */
-    deriveKey(algorithm: string | SubtleCryptoDeriveKeyAlgorithm, baseKey: CryptoKey, derivedKeyAlgorithm: string | SubtleCryptoImportKeyAlgorithm, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits) */
-    deriveBits(algorithm: string | SubtleCryptoDeriveKeyAlgorithm, baseKey: CryptoKey, length?: number | null): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey) */
-    importKey(format: string, keyData: (ArrayBuffer | ArrayBufferView) | JsonWebKey, algorithm: string | SubtleCryptoImportKeyAlgorithm, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey) */
-    exportKey(format: string, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey) */
-    wrapKey(format: string, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: string | SubtleCryptoEncryptAlgorithm): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey) */
-    unwrapKey(format: string, wrappedKey: ArrayBuffer | ArrayBufferView, unwrappingKey: CryptoKey, unwrapAlgorithm: string | SubtleCryptoEncryptAlgorithm, unwrappedKeyAlgorithm: string | SubtleCryptoImportKeyAlgorithm, extractable: boolean, keyUsages: string[]): Promise<CryptoKey>;
-    timingSafeEqual(a: ArrayBuffer | ArrayBufferView, b: ArrayBuffer | ArrayBufferView): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt) */
+  encrypt(
+    algorithm: string | SubtleCryptoEncryptAlgorithm,
+    key: CryptoKey,
+    plainText: ArrayBuffer | ArrayBufferView,
+  ): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt) */
+  decrypt(
+    algorithm: string | SubtleCryptoEncryptAlgorithm,
+    key: CryptoKey,
+    cipherText: ArrayBuffer | ArrayBufferView,
+  ): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign) */
+  sign(
+    algorithm: string | SubtleCryptoSignAlgorithm,
+    key: CryptoKey,
+    data: ArrayBuffer | ArrayBufferView,
+  ): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify) */
+  verify(
+    algorithm: string | SubtleCryptoSignAlgorithm,
+    key: CryptoKey,
+    signature: ArrayBuffer | ArrayBufferView,
+    data: ArrayBuffer | ArrayBufferView,
+  ): Promise<boolean>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/digest) */
+  digest(
+    algorithm: string | SubtleCryptoHashAlgorithm,
+    data: ArrayBuffer | ArrayBufferView,
+  ): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey) */
+  generateKey(
+    algorithm: string | SubtleCryptoGenerateKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: string[],
+  ): Promise<CryptoKey | CryptoKeyPair>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey) */
+  deriveKey(
+    algorithm: string | SubtleCryptoDeriveKeyAlgorithm,
+    baseKey: CryptoKey,
+    derivedKeyAlgorithm: string | SubtleCryptoImportKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: string[],
+  ): Promise<CryptoKey>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits) */
+  deriveBits(
+    algorithm: string | SubtleCryptoDeriveKeyAlgorithm,
+    baseKey: CryptoKey,
+    length?: number | null,
+  ): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey) */
+  importKey(
+    format: string,
+    keyData: (ArrayBuffer | ArrayBufferView) | JsonWebKey,
+    algorithm: string | SubtleCryptoImportKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: string[],
+  ): Promise<CryptoKey>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey) */
+  exportKey(format: string, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey) */
+  wrapKey(
+    format: string,
+    key: CryptoKey,
+    wrappingKey: CryptoKey,
+    wrapAlgorithm: string | SubtleCryptoEncryptAlgorithm,
+  ): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey) */
+  unwrapKey(
+    format: string,
+    wrappedKey: ArrayBuffer | ArrayBufferView,
+    unwrappingKey: CryptoKey,
+    unwrapAlgorithm: string | SubtleCryptoEncryptAlgorithm,
+    unwrappedKeyAlgorithm: string | SubtleCryptoImportKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: string[],
+  ): Promise<CryptoKey>;
+  timingSafeEqual(a: ArrayBuffer | ArrayBufferView, b: ArrayBuffer | ArrayBufferView): boolean;
 }
 /**
  * The CryptoKey dictionary of the Web Crypto API represents a cryptographic key.
@@ -899,117 +1080,123 @@ declare abstract class SubtleCrypto {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey)
  */
 declare abstract class CryptoKey {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/type) */
-    readonly type: string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/extractable) */
-    readonly extractable: boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/algorithm) */
-    readonly algorithm: CryptoKeyKeyAlgorithm | CryptoKeyAesKeyAlgorithm | CryptoKeyHmacKeyAlgorithm | CryptoKeyRsaKeyAlgorithm | CryptoKeyEllipticKeyAlgorithm | CryptoKeyArbitraryKeyAlgorithm;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/usages) */
-    readonly usages: string[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/type) */
+  readonly type: string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/extractable) */
+  readonly extractable: boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/algorithm) */
+  readonly algorithm:
+    | CryptoKeyKeyAlgorithm
+    | CryptoKeyAesKeyAlgorithm
+    | CryptoKeyHmacKeyAlgorithm
+    | CryptoKeyRsaKeyAlgorithm
+    | CryptoKeyEllipticKeyAlgorithm
+    | CryptoKeyArbitraryKeyAlgorithm;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/usages) */
+  readonly usages: string[];
 }
 interface CryptoKeyPair {
-    publicKey: CryptoKey;
-    privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
 }
 interface JsonWebKey {
-    kty: string;
-    use?: string;
-    key_ops?: string[];
-    alg?: string;
-    ext?: boolean;
-    crv?: string;
-    x?: string;
-    y?: string;
-    d?: string;
-    n?: string;
-    e?: string;
-    p?: string;
-    q?: string;
-    dp?: string;
-    dq?: string;
-    qi?: string;
-    oth?: RsaOtherPrimesInfo[];
-    k?: string;
+  kty: string;
+  use?: string;
+  key_ops?: string[];
+  alg?: string;
+  ext?: boolean;
+  crv?: string;
+  x?: string;
+  y?: string;
+  d?: string;
+  n?: string;
+  e?: string;
+  p?: string;
+  q?: string;
+  dp?: string;
+  dq?: string;
+  qi?: string;
+  oth?: RsaOtherPrimesInfo[];
+  k?: string;
 }
 interface RsaOtherPrimesInfo {
-    r?: string;
-    d?: string;
-    t?: string;
+  r?: string;
+  d?: string;
+  t?: string;
 }
 interface SubtleCryptoDeriveKeyAlgorithm {
-    name: string;
-    salt?: (ArrayBuffer | ArrayBufferView);
-    iterations?: number;
-    hash?: (string | SubtleCryptoHashAlgorithm);
-    $public?: CryptoKey;
-    info?: (ArrayBuffer | ArrayBufferView);
+  name: string;
+  salt?: ArrayBuffer | ArrayBufferView;
+  iterations?: number;
+  hash?: string | SubtleCryptoHashAlgorithm;
+  $public?: CryptoKey;
+  info?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoEncryptAlgorithm {
-    name: string;
-    iv?: (ArrayBuffer | ArrayBufferView);
-    additionalData?: (ArrayBuffer | ArrayBufferView);
-    tagLength?: number;
-    counter?: (ArrayBuffer | ArrayBufferView);
-    length?: number;
-    label?: (ArrayBuffer | ArrayBufferView);
+  name: string;
+  iv?: ArrayBuffer | ArrayBufferView;
+  additionalData?: ArrayBuffer | ArrayBufferView;
+  tagLength?: number;
+  counter?: ArrayBuffer | ArrayBufferView;
+  length?: number;
+  label?: ArrayBuffer | ArrayBufferView;
 }
 interface SubtleCryptoGenerateKeyAlgorithm {
-    name: string;
-    hash?: (string | SubtleCryptoHashAlgorithm);
-    modulusLength?: number;
-    publicExponent?: (ArrayBuffer | ArrayBufferView);
-    length?: number;
-    namedCurve?: string;
+  name: string;
+  hash?: string | SubtleCryptoHashAlgorithm;
+  modulusLength?: number;
+  publicExponent?: ArrayBuffer | ArrayBufferView;
+  length?: number;
+  namedCurve?: string;
 }
 interface SubtleCryptoHashAlgorithm {
-    name: string;
+  name: string;
 }
 interface SubtleCryptoImportKeyAlgorithm {
-    name: string;
-    hash?: (string | SubtleCryptoHashAlgorithm);
-    length?: number;
-    namedCurve?: string;
-    compressed?: boolean;
+  name: string;
+  hash?: string | SubtleCryptoHashAlgorithm;
+  length?: number;
+  namedCurve?: string;
+  compressed?: boolean;
 }
 interface SubtleCryptoSignAlgorithm {
-    name: string;
-    hash?: (string | SubtleCryptoHashAlgorithm);
-    dataLength?: number;
-    saltLength?: number;
+  name: string;
+  hash?: string | SubtleCryptoHashAlgorithm;
+  dataLength?: number;
+  saltLength?: number;
 }
 interface CryptoKeyKeyAlgorithm {
-    name: string;
+  name: string;
 }
 interface CryptoKeyAesKeyAlgorithm {
-    name: string;
-    length: number;
+  name: string;
+  length: number;
 }
 interface CryptoKeyHmacKeyAlgorithm {
-    name: string;
-    hash: CryptoKeyKeyAlgorithm;
-    length: number;
+  name: string;
+  hash: CryptoKeyKeyAlgorithm;
+  length: number;
 }
 interface CryptoKeyRsaKeyAlgorithm {
-    name: string;
-    modulusLength: number;
-    publicExponent: ArrayBuffer | ArrayBufferView;
-    hash?: CryptoKeyKeyAlgorithm;
+  name: string;
+  modulusLength: number;
+  publicExponent: ArrayBuffer | ArrayBufferView;
+  hash?: CryptoKeyKeyAlgorithm;
 }
 interface CryptoKeyEllipticKeyAlgorithm {
-    name: string;
-    namedCurve: string;
+  name: string;
+  namedCurve: string;
 }
 interface CryptoKeyArbitraryKeyAlgorithm {
-    name: string;
-    hash?: CryptoKeyKeyAlgorithm;
-    namedCurve?: string;
-    length?: number;
+  name: string;
+  hash?: CryptoKeyKeyAlgorithm;
+  namedCurve?: string;
+  length?: number;
 }
 declare class DigestStream extends WritableStream<ArrayBuffer | ArrayBufferView> {
-    constructor(algorithm: string | SubtleCryptoHashAlgorithm);
-    readonly digest: Promise<ArrayBuffer>;
-    get bytesWritten(): number | bigint;
+  constructor(algorithm: string | SubtleCryptoHashAlgorithm);
+  readonly digest: Promise<ArrayBuffer>;
+  get bytesWritten(): number | bigint;
 }
 /**
  * A decoder for a specific method, that is a specific character encoding, like utf-8, iso-8859-2, koi8, cp1261, gbk, etc. A decoder takes a stream of bytes as input and emits a stream of code points. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays.
@@ -1017,26 +1204,26 @@ declare class DigestStream extends WritableStream<ArrayBuffer | ArrayBufferView>
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextDecoder)
  */
 declare class TextDecoder {
-    constructor(label?: string, options?: TextDecoderConstructorOptions);
-    /**
-     * Returns the result of running encoding's decoder. The method can be invoked zero or more times with options's stream set to true, and then once without options's stream (or set to false), to process a fragmented input. If the invocation without options's stream (or set to false) has no input, it's clearest to omit both arguments.
-     *
-     * ```
-     * var string = "", decoder = new TextDecoder(encoding), buffer;
-     * while(buffer = next_chunk()) {
-     *   string += decoder.decode(buffer, {stream:true});
-     * }
-     * string += decoder.decode(); // end-of-queue
-     * ```
-     *
-     * If the error mode is "fatal" and encoding's decoder returns error, throws a TypeError.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextDecoder/decode)
-     */
-    decode(input?: (ArrayBuffer | ArrayBufferView), options?: TextDecoderDecodeOptions): string;
-    get encoding(): string;
-    get fatal(): boolean;
-    get ignoreBOM(): boolean;
+  constructor(label?: string, options?: TextDecoderConstructorOptions);
+  /**
+   * Returns the result of running encoding's decoder. The method can be invoked zero or more times with options's stream set to true, and then once without options's stream (or set to false), to process a fragmented input. If the invocation without options's stream (or set to false) has no input, it's clearest to omit both arguments.
+   *
+   * ```
+   * var string = "", decoder = new TextDecoder(encoding), buffer;
+   * while(buffer = next_chunk()) {
+   *   string += decoder.decode(buffer, {stream:true});
+   * }
+   * string += decoder.decode(); // end-of-queue
+   * ```
+   *
+   * If the error mode is "fatal" and encoding's decoder returns error, throws a TypeError.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextDecoder/decode)
+   */
+  decode(input?: ArrayBuffer | ArrayBufferView, options?: TextDecoderDecodeOptions): string;
+  get encoding(): string;
+  get fatal(): boolean;
+  get ignoreBOM(): boolean;
 }
 /**
  * TextEncoder takes a stream of code points as input and emits a stream of bytes. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays.
@@ -1044,31 +1231,31 @@ declare class TextDecoder {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoder)
  */
 declare class TextEncoder {
-    constructor();
-    /**
-     * Returns the result of running UTF-8's encoder.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoder/encode)
-     */
-    encode(input?: string): Uint8Array;
-    /**
-     * Runs the UTF-8 encoder on source, stores the result of that operation into destination, and returns the progress made as an object wherein read is the number of converted code units of source and written is the number of bytes modified in destination.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoder/encodeInto)
-     */
-    encodeInto(input: string, buffer: ArrayBuffer | ArrayBufferView): TextEncoderEncodeIntoResult;
-    get encoding(): string;
+  constructor();
+  /**
+   * Returns the result of running UTF-8's encoder.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoder/encode)
+   */
+  encode(input?: string): Uint8Array;
+  /**
+   * Runs the UTF-8 encoder on source, stores the result of that operation into destination, and returns the progress made as an object wherein read is the number of converted code units of source and written is the number of bytes modified in destination.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoder/encodeInto)
+   */
+  encodeInto(input: string, buffer: ArrayBuffer | ArrayBufferView): TextEncoderEncodeIntoResult;
+  get encoding(): string;
 }
 interface TextDecoderConstructorOptions {
-    fatal: boolean;
-    ignoreBOM: boolean;
+  fatal: boolean;
+  ignoreBOM: boolean;
 }
 interface TextDecoderDecodeOptions {
-    stream: boolean;
+  stream: boolean;
 }
 interface TextEncoderEncodeIntoResult {
-    read: number;
-    written: number;
+  read: number;
+  written: number;
 }
 /**
  * Events providing information related to errors in scripts or in files.
@@ -1076,24 +1263,24 @@ interface TextEncoderEncodeIntoResult {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent)
  */
 declare class ErrorEvent extends Event {
-    constructor(type: string, init?: ErrorEventErrorEventInit);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
-    get filename(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
-    get message(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
-    get lineno(): number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
-    get colno(): number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
-    get error(): any;
+  constructor(type: string, init?: ErrorEventErrorEventInit);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename) */
+  get filename(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/message) */
+  get message(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno) */
+  get lineno(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno) */
+  get colno(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ErrorEvent/error) */
+  get error(): any;
 }
 interface ErrorEventErrorEventInit {
-    message?: string;
-    filename?: string;
-    lineno?: number;
-    colno?: number;
-    error?: any;
+  message?: string;
+  filename?: string;
+  lineno?: number;
+  colno?: number;
+  error?: any;
 }
 /**
  * A message received by a target object.
@@ -1101,40 +1288,40 @@ interface ErrorEventErrorEventInit {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent)
  */
 declare class MessageEvent extends Event {
-    constructor(type: string, initializer: MessageEventInit);
-    /**
-     * Returns the data of the message.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
-     */
-    readonly data: any;
-    /**
-     * Returns the origin of the message, for server-sent events and cross-document messaging.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/origin)
-     */
-    readonly origin: string | null;
-    /**
-     * Returns the last event ID string, for server-sent events.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/lastEventId)
-     */
-    readonly lastEventId: string;
-    /**
-     * Returns the WindowProxy of the source window, for cross-document messaging, and the MessagePort being attached, in the connect event fired at SharedWorkerGlobalScope objects.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/source)
-     */
-    readonly source: MessagePort | null;
-    /**
-     * Returns the MessagePort array sent with the message, for cross-document messaging and channel messaging.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/ports)
-     */
-    readonly ports: MessagePort[];
+  constructor(type: string, initializer: MessageEventInit);
+  /**
+   * Returns the data of the message.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
+   */
+  readonly data: any;
+  /**
+   * Returns the origin of the message, for server-sent events and cross-document messaging.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/origin)
+   */
+  readonly origin: string | null;
+  /**
+   * Returns the last event ID string, for server-sent events.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/lastEventId)
+   */
+  readonly lastEventId: string;
+  /**
+   * Returns the WindowProxy of the source window, for cross-document messaging, and the MessagePort being attached, in the connect event fired at SharedWorkerGlobalScope objects.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/source)
+   */
+  readonly source: MessagePort | null;
+  /**
+   * Returns the MessagePort array sent with the message, for cross-document messaging and channel messaging.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/ports)
+   */
+  readonly ports: MessagePort[];
 }
 interface MessageEventInit {
-    data: ArrayBuffer | string;
+  data: ArrayBuffer | string;
 }
 /**
  * Provides a way to easily construct a set of key/value pairs representing form fields and their values, which can then be easily sent using the XMLHttpRequest.send() method. It uses the same format a form would use if the encoding type were set to "multipart/form-data".
@@ -1142,107 +1329,104 @@ interface MessageEventInit {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData)
  */
 declare class FormData {
-    constructor();
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(name: string, value: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(name: string, value: Blob, filename?: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
-    delete(name: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
-    get(name: string): (File | string) | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll) */
-    getAll(name: string): (File | string)[];
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
-    has(name: string): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(name: string, value: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(name: string, value: Blob, filename?: string): void;
-    /* Returns an array of key, value pairs for every entry in the list. */
-    entries(): IterableIterator<[
-        key: string,
-        value: File | string
-    ]>;
-    /* Returns a list of keys in the list. */
-    keys(): IterableIterator<string>;
-    /* Returns a list of values in the list. */
-    values(): IterableIterator<(File | string)>;
-    forEach<This = unknown>(callback: (this: This, value: File | string, key: string, parent: FormData) => void, thisArg?: This): void;
-    [Symbol.iterator](): IterableIterator<[
-        key: string,
-        value: File | string
-    ]>;
+  constructor();
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+  append(name: string, value: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+  append(name: string, value: Blob, filename?: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
+  delete(name: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
+  get(name: string): (File | string) | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll) */
+  getAll(name: string): (File | string)[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
+  has(name: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+  set(name: string, value: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+  set(name: string, value: Blob, filename?: string): void;
+  /* Returns an array of key, value pairs for every entry in the list. */
+  entries(): IterableIterator<[key: string, value: File | string]>;
+  /* Returns a list of keys in the list. */
+  keys(): IterableIterator<string>;
+  /* Returns a list of values in the list. */
+  values(): IterableIterator<File | string>;
+  forEach<This = unknown>(
+    callback: (this: This, value: File | string, key: string, parent: FormData) => void,
+    thisArg?: This,
+  ): void;
+  [Symbol.iterator](): IterableIterator<[key: string, value: File | string]>;
 }
 interface ContentOptions {
-    html?: boolean;
+  html?: boolean;
 }
 declare class HTMLRewriter {
-    constructor();
-    on(selector: string, handlers: HTMLRewriterElementContentHandlers): HTMLRewriter;
-    onDocument(handlers: HTMLRewriterDocumentContentHandlers): HTMLRewriter;
-    transform(response: Response): Response;
+  constructor();
+  on(selector: string, handlers: HTMLRewriterElementContentHandlers): HTMLRewriter;
+  onDocument(handlers: HTMLRewriterDocumentContentHandlers): HTMLRewriter;
+  transform(response: Response): Response;
 }
 interface HTMLRewriterElementContentHandlers {
-    element?(element: Element): void | Promise<void>;
-    comments?(comment: Comment): void | Promise<void>;
-    text?(element: Text): void | Promise<void>;
+  element?(element: Element): void | Promise<void>;
+  comments?(comment: Comment): void | Promise<void>;
+  text?(element: Text): void | Promise<void>;
 }
 interface HTMLRewriterDocumentContentHandlers {
-    doctype?(doctype: Doctype): void | Promise<void>;
-    comments?(comment: Comment): void | Promise<void>;
-    text?(text: Text): void | Promise<void>;
-    end?(end: DocumentEnd): void | Promise<void>;
+  doctype?(doctype: Doctype): void | Promise<void>;
+  comments?(comment: Comment): void | Promise<void>;
+  text?(text: Text): void | Promise<void>;
+  end?(end: DocumentEnd): void | Promise<void>;
 }
 interface Doctype {
-    readonly name: string | null;
-    readonly publicId: string | null;
-    readonly systemId: string | null;
+  readonly name: string | null;
+  readonly publicId: string | null;
+  readonly systemId: string | null;
 }
 interface Element {
-    tagName: string;
-    readonly attributes: IterableIterator<string[]>;
-    readonly removed: boolean;
-    readonly namespaceURI: string;
-    getAttribute(name: string): string | null;
-    hasAttribute(name: string): boolean;
-    setAttribute(name: string, value: string): Element;
-    removeAttribute(name: string): Element;
-    before(content: string | ReadableStream | Response, options?: ContentOptions): Element;
-    after(content: string | ReadableStream | Response, options?: ContentOptions): Element;
-    prepend(content: string | ReadableStream | Response, options?: ContentOptions): Element;
-    append(content: string | ReadableStream | Response, options?: ContentOptions): Element;
-    replace(content: string | ReadableStream | Response, options?: ContentOptions): Element;
-    remove(): Element;
-    removeAndKeepContent(): Element;
-    setInnerContent(content: string | ReadableStream | Response, options?: ContentOptions): Element;
-    onEndTag(handler: (tag: EndTag) => void | Promise<void>): void;
+  tagName: string;
+  readonly attributes: IterableIterator<string[]>;
+  readonly removed: boolean;
+  readonly namespaceURI: string;
+  getAttribute(name: string): string | null;
+  hasAttribute(name: string): boolean;
+  setAttribute(name: string, value: string): Element;
+  removeAttribute(name: string): Element;
+  before(content: string | ReadableStream | Response, options?: ContentOptions): Element;
+  after(content: string | ReadableStream | Response, options?: ContentOptions): Element;
+  prepend(content: string | ReadableStream | Response, options?: ContentOptions): Element;
+  append(content: string | ReadableStream | Response, options?: ContentOptions): Element;
+  replace(content: string | ReadableStream | Response, options?: ContentOptions): Element;
+  remove(): Element;
+  removeAndKeepContent(): Element;
+  setInnerContent(content: string | ReadableStream | Response, options?: ContentOptions): Element;
+  onEndTag(handler: (tag: EndTag) => void | Promise<void>): void;
 }
 interface EndTag {
-    name: string;
-    before(content: string | ReadableStream | Response, options?: ContentOptions): EndTag;
-    after(content: string | ReadableStream | Response, options?: ContentOptions): EndTag;
-    remove(): EndTag;
+  name: string;
+  before(content: string | ReadableStream | Response, options?: ContentOptions): EndTag;
+  after(content: string | ReadableStream | Response, options?: ContentOptions): EndTag;
+  remove(): EndTag;
 }
 interface Comment {
-    text: string;
-    readonly removed: boolean;
-    before(content: string, options?: ContentOptions): Comment;
-    after(content: string, options?: ContentOptions): Comment;
-    replace(content: string, options?: ContentOptions): Comment;
-    remove(): Comment;
+  text: string;
+  readonly removed: boolean;
+  before(content: string, options?: ContentOptions): Comment;
+  after(content: string, options?: ContentOptions): Comment;
+  replace(content: string, options?: ContentOptions): Comment;
+  remove(): Comment;
 }
 interface Text {
-    readonly text: string;
-    readonly lastInTextNode: boolean;
-    readonly removed: boolean;
-    before(content: string | ReadableStream | Response, options?: ContentOptions): Text;
-    after(content: string | ReadableStream | Response, options?: ContentOptions): Text;
-    replace(content: string | ReadableStream | Response, options?: ContentOptions): Text;
-    remove(): Text;
+  readonly text: string;
+  readonly lastInTextNode: boolean;
+  readonly removed: boolean;
+  before(content: string | ReadableStream | Response, options?: ContentOptions): Text;
+  after(content: string | ReadableStream | Response, options?: ContentOptions): Text;
+  replace(content: string | ReadableStream | Response, options?: ContentOptions): Text;
+  remove(): Text;
 }
 interface DocumentEnd {
-    append(content: string, options?: ContentOptions): DocumentEnd;
+  append(content: string, options?: ContentOptions): DocumentEnd;
 }
 /**
  * This is the event type for fetch events dispatched on the service worker global scope. It contains information about the fetch, including the request and how the receiver will treat the response. It provides the event.respondWith() method, which allows us to provide a response to this fetch.
@@ -1250,11 +1434,11 @@ interface DocumentEnd {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FetchEvent)
  */
 declare abstract class FetchEvent extends ExtendableEvent {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FetchEvent/request) */
-    readonly request: Request;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FetchEvent/respondWith) */
-    respondWith(promise: Response | Promise<Response>): void;
-    passThroughOnException(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FetchEvent/request) */
+  readonly request: Request;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/FetchEvent/respondWith) */
+  respondWith(promise: Response | Promise<Response>): void;
+  passThroughOnException(): void;
 }
 type HeadersInit = Headers | Iterable<Iterable<string>> | Record<string, string>;
 /**
@@ -1263,53 +1447,57 @@ type HeadersInit = Headers | Iterable<Iterable<string>> | Record<string, string>
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers)
  */
 declare class Headers {
-    constructor(init?: HeadersInit);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/get) */
-    get(name: string): string | null;
-    getAll(name: string): string[];
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie) */
-    getSetCookie(): string[];
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/has) */
-    has(name: string): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set) */
-    set(name: string, value: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append) */
-    append(name: string, value: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/delete) */
-    delete(name: string): void;
-    forEach<This = unknown>(callback: (this: This, value: string, key: string, parent: Headers) => void, thisArg?: This): void;
-    /* Returns an iterator allowing to go through all key/value pairs contained in this object. */
-    entries(): IterableIterator<[
-        key: string,
-        value: string
-    ]>;
-    /* Returns an iterator allowing to go through all keys of the key/value pairs contained in this object. */
-    keys(): IterableIterator<string>;
-    /* Returns an iterator allowing to go through all values of the key/value pairs contained in this object. */
-    values(): IterableIterator<string>;
-    [Symbol.iterator](): IterableIterator<[
-        key: string,
-        value: string
-    ]>;
+  constructor(init?: HeadersInit);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/get) */
+  get(name: string): string | null;
+  getAll(name: string): string[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie) */
+  getSetCookie(): string[];
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/has) */
+  has(name: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set) */
+  set(name: string, value: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append) */
+  append(name: string, value: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/delete) */
+  delete(name: string): void;
+  forEach<This = unknown>(
+    callback: (this: This, value: string, key: string, parent: Headers) => void,
+    thisArg?: This,
+  ): void;
+  /* Returns an iterator allowing to go through all key/value pairs contained in this object. */
+  entries(): IterableIterator<[key: string, value: string]>;
+  /* Returns an iterator allowing to go through all keys of the key/value pairs contained in this object. */
+  keys(): IterableIterator<string>;
+  /* Returns an iterator allowing to go through all values of the key/value pairs contained in this object. */
+  values(): IterableIterator<string>;
+  [Symbol.iterator](): IterableIterator<[key: string, value: string]>;
 }
-type BodyInit = ReadableStream<Uint8Array> | string | ArrayBuffer | ArrayBufferView | Blob | URLSearchParams | FormData;
+type BodyInit =
+  | ReadableStream<Uint8Array>
+  | string
+  | ArrayBuffer
+  | ArrayBufferView
+  | Blob
+  | URLSearchParams
+  | FormData;
 declare abstract class Body {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
-    get body(): ReadableStream | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
-    get bodyUsed(): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer) */
-    arrayBuffer(): Promise<ArrayBuffer>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
-    bytes(): Promise<Uint8Array>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
-    text(): Promise<string>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
-    json<T>(): Promise<T>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
-    formData(): Promise<FormData>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
-    blob(): Promise<Blob>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
+  get body(): ReadableStream | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
+  get bodyUsed(): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer) */
+  arrayBuffer(): Promise<ArrayBuffer>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
+  bytes(): Promise<Uint8Array>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
+  text(): Promise<string>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
+  json<T>(): Promise<T>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
+  formData(): Promise<FormData>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
+  blob(): Promise<Blob>;
 }
 /**
  * This Fetch API interface represents the response to a request.
@@ -1317,11 +1505,11 @@ declare abstract class Body {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response)
  */
 declare var Response: {
-    prototype: Response;
-    new (body?: BodyInit | null, init?: ResponseInit): Response;
-    error(): Response;
-    redirect(url: string, status?: number): Response;
-    json(any: any, maybeInit?: (ResponseInit | Response)): Response;
+  prototype: Response;
+  new (body?: BodyInit | null, init?: ResponseInit): Response;
+  error(): Response;
+  redirect(url: string, status?: number): Response;
+  json(any: any, maybeInit?: ResponseInit | Response): Response;
 };
 /**
  * This Fetch API interface represents the response to a request.
@@ -1329,42 +1517,47 @@ declare var Response: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response)
  */
 interface Response extends Body {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/clone) */
-    clone(): Response;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/status) */
-    status: number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/statusText) */
-    statusText: string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/headers) */
-    headers: Headers;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/ok) */
-    ok: boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/redirected) */
-    redirected: boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/url) */
-    url: string;
-    webSocket: WebSocket | null;
-    cf: any | undefined;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
-    type: "default" | "error";
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/clone) */
+  clone(): Response;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/status) */
+  status: number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/statusText) */
+  statusText: string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/headers) */
+  headers: Headers;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/ok) */
+  ok: boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/redirected) */
+  redirected: boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/url) */
+  url: string;
+  webSocket: WebSocket | null;
+  cf: any | undefined;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/type) */
+  type: "default" | "error";
 }
 interface ResponseInit {
-    status?: number;
-    statusText?: string;
-    headers?: HeadersInit;
-    cf?: any;
-    webSocket?: (WebSocket | null);
-    encodeBody?: "automatic" | "manual";
+  status?: number;
+  statusText?: string;
+  headers?: HeadersInit;
+  cf?: any;
+  webSocket?: WebSocket | null;
+  encodeBody?: "automatic" | "manual";
 }
-type RequestInfo<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> = Request<CfHostMetadata, Cf> | string;
+type RequestInfo<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> =
+  | Request<CfHostMetadata, Cf>
+  | string;
 /**
  * This Fetch API interface represents a resource request.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request)
  */
 declare var Request: {
-    prototype: Request;
-    new <CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>(input: RequestInfo<CfProperties> | URL, init?: RequestInit<Cf>): Request<CfHostMetadata, Cf>;
+  prototype: Request;
+  new <CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>(
+    input: RequestInfo<CfProperties> | URL,
+    init?: RequestInit<Cf>,
+  ): Request<CfHostMetadata, Cf>;
 };
 /**
  * This Fetch API interface represents a resource request.
@@ -1372,428 +1565,536 @@ declare var Request: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request)
  */
 interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> extends Body {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/clone) */
-    clone(): Request<CfHostMetadata, Cf>;
-    /**
-     * Returns request's HTTP method, which is "GET" by default.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/method)
-     */
-    method: string;
-    /**
-     * Returns the URL of request as a string.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/url)
-     */
-    url: string;
-    /**
-     * Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/headers)
-     */
-    headers: Headers;
-    /**
-     * Returns the redirect mode associated with request, which is a string indicating how redirects for the request will be handled during fetching. A request will follow redirects by default.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/redirect)
-     */
-    redirect: string;
-    fetcher: Fetcher | null;
-    /**
-     * Returns the signal associated with request, which is an AbortSignal object indicating whether or not request has been aborted, and its abort event handler.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/signal)
-     */
-    signal: AbortSignal;
-    cf: Cf | undefined;
-    /**
-     * Returns request's subresource integrity metadata, which is a cryptographic hash of the resource being fetched. Its value consists of multiple hashes separated by whitespace. [SRI]
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
-     */
-    integrity: string;
-    /**
-     * Returns a boolean indicating whether or not request can outlive the global in which it was created.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
-     */
-    keepalive: boolean;
-    /**
-     * Returns the cache mode associated with request, which is a string indicating how the request will interact with the browser's cache when fetching.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/cache)
-     */
-    cache?: "no-store";
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/clone) */
+  clone(): Request<CfHostMetadata, Cf>;
+  /**
+   * Returns request's HTTP method, which is "GET" by default.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/method)
+   */
+  method: string;
+  /**
+   * Returns the URL of request as a string.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/url)
+   */
+  url: string;
+  /**
+   * Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/headers)
+   */
+  headers: Headers;
+  /**
+   * Returns the redirect mode associated with request, which is a string indicating how redirects for the request will be handled during fetching. A request will follow redirects by default.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/redirect)
+   */
+  redirect: string;
+  fetcher: Fetcher | null;
+  /**
+   * Returns the signal associated with request, which is an AbortSignal object indicating whether or not request has been aborted, and its abort event handler.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/signal)
+   */
+  signal: AbortSignal;
+  cf: Cf | undefined;
+  /**
+   * Returns request's subresource integrity metadata, which is a cryptographic hash of the resource being fetched. Its value consists of multiple hashes separated by whitespace. [SRI]
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/integrity)
+   */
+  integrity: string;
+  /**
+   * Returns a boolean indicating whether or not request can outlive the global in which it was created.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/keepalive)
+   */
+  keepalive: boolean;
+  /**
+   * Returns the cache mode associated with request, which is a string indicating how the request will interact with the browser's cache when fetching.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/cache)
+   */
+  cache?: "no-store";
 }
 interface RequestInit<Cf = CfProperties> {
-    /* A string to set request's method. */
-    method?: string;
-    /* A Headers object, an object literal, or an array of two-item arrays to set request's headers. */
-    headers?: HeadersInit;
-    /* A BodyInit object or null to set request's body. */
-    body?: BodyInit | null;
-    /* A string indicating whether request follows redirects, results in an error upon encountering a redirect, or returns the redirect (in an opaque fashion). Sets request's redirect. */
-    redirect?: string;
-    fetcher?: (Fetcher | null);
-    cf?: Cf;
-    /* A string indicating how the request will interact with the browser's cache to set request's cache. */
-    cache?: "no-store";
-    /* A cryptographic hash of the resource to be fetched by request. Sets request's integrity. */
-    integrity?: string;
-    /* An AbortSignal to set request's signal. */
-    signal?: (AbortSignal | null);
-    encodeResponseBody?: "automatic" | "manual";
+  /* A string to set request's method. */
+  method?: string;
+  /* A Headers object, an object literal, or an array of two-item arrays to set request's headers. */
+  headers?: HeadersInit;
+  /* A BodyInit object or null to set request's body. */
+  body?: BodyInit | null;
+  /* A string indicating whether request follows redirects, results in an error upon encountering a redirect, or returns the redirect (in an opaque fashion). Sets request's redirect. */
+  redirect?: string;
+  fetcher?: Fetcher | null;
+  cf?: Cf;
+  /* A string indicating how the request will interact with the browser's cache to set request's cache. */
+  cache?: "no-store";
+  /* A cryptographic hash of the resource to be fetched by request. Sets request's integrity. */
+  integrity?: string;
+  /* An AbortSignal to set request's signal. */
+  signal?: AbortSignal | null;
+  encodeResponseBody?: "automatic" | "manual";
 }
-type Service<T extends (new (...args: any[]) => Rpc.WorkerEntrypointBranded) | Rpc.WorkerEntrypointBranded | ExportedHandler<any, any, any> | undefined = undefined> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded ? Fetcher<InstanceType<T>> : T extends Rpc.WorkerEntrypointBranded ? Fetcher<T> : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded> ? never : Fetcher<undefined>;
-type Fetcher<T extends Rpc.EntrypointBranded | undefined = undefined, Reserved extends string = never> = (T extends Rpc.EntrypointBranded ? Rpc.Provider<T, Reserved | "fetch" | "connect"> : unknown) & {
-    fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
-    connect(address: SocketAddress | string, options?: SocketOptions): Socket;
+type Service<
+  T extends
+    | (new (...args: any[]) => Rpc.WorkerEntrypointBranded)
+    | Rpc.WorkerEntrypointBranded
+    | ExportedHandler<any, any, any>
+    | undefined = undefined,
+> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
+  ? Fetcher<InstanceType<T>>
+  : T extends Rpc.WorkerEntrypointBranded
+    ? Fetcher<T>
+    : T extends Exclude<Rpc.EntrypointBranded, Rpc.WorkerEntrypointBranded>
+      ? never
+      : Fetcher<undefined>;
+type Fetcher<
+  T extends Rpc.EntrypointBranded | undefined = undefined,
+  Reserved extends string = never,
+> = (T extends Rpc.EntrypointBranded
+  ? Rpc.Provider<T, Reserved | "fetch" | "connect">
+  : unknown) & {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  connect(address: SocketAddress | string, options?: SocketOptions): Socket;
 };
 interface KVNamespaceListKey<Metadata, Key extends string = string> {
-    name: Key;
-    expiration?: number;
-    metadata?: Metadata;
+  name: Key;
+  expiration?: number;
+  metadata?: Metadata;
 }
-type KVNamespaceListResult<Metadata, Key extends string = string> = {
-    list_complete: false;
-    keys: KVNamespaceListKey<Metadata, Key>[];
-    cursor: string;
-    cacheStatus: string | null;
-} | {
-    list_complete: true;
-    keys: KVNamespaceListKey<Metadata, Key>[];
-    cacheStatus: string | null;
-};
+type KVNamespaceListResult<Metadata, Key extends string = string> =
+  | {
+      list_complete: false;
+      keys: KVNamespaceListKey<Metadata, Key>[];
+      cursor: string;
+      cacheStatus: string | null;
+    }
+  | {
+      list_complete: true;
+      keys: KVNamespaceListKey<Metadata, Key>[];
+      cacheStatus: string | null;
+    };
 interface KVNamespace<Key extends string = string> {
-    get(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<string | null>;
-    get(key: Key, type: "text"): Promise<string | null>;
-    get<ExpectedValue = unknown>(key: Key, type: "json"): Promise<ExpectedValue | null>;
-    get(key: Key, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
-    get(key: Key, type: "stream"): Promise<ReadableStream | null>;
-    get(key: Key, options?: KVNamespaceGetOptions<"text">): Promise<string | null>;
-    get<ExpectedValue = unknown>(key: Key, options?: KVNamespaceGetOptions<"json">): Promise<ExpectedValue | null>;
-    get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<ArrayBuffer | null>;
-    get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<ReadableStream | null>;
-    get(key: Array<Key>, type: "text"): Promise<Map<string, string | null>>;
-    get<ExpectedValue = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, ExpectedValue | null>>;
-    get(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, string | null>>;
-    get(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, string | null>>;
-    get<ExpectedValue = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, ExpectedValue | null>>;
-    list<Metadata = unknown>(options?: KVNamespaceListOptions): Promise<KVNamespaceListResult<Metadata, Key>>;
-    put(key: Key, value: string | ArrayBuffer | ArrayBufferView | ReadableStream, options?: KVNamespacePutOptions): Promise<void>;
-    getWithMetadata<Metadata = unknown>(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Key, type: "text"): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
-    getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, type: "json"): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Key, type: "arrayBuffer"): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Key, type: "stream"): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"text">): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
-    getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"json">): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"arrayBuffer">): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Key, options: KVNamespaceGetOptions<"stream">): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
-    getWithMetadata<Metadata = unknown>(key: Array<Key>, type: "text"): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
-    getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, type: "json"): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>>;
-    getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
-    getWithMetadata<Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"text">): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
-    getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(key: Array<Key>, options?: KVNamespaceGetOptions<"json">): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>>;
-    delete(key: Key): Promise<void>;
+  get(key: Key, options?: Partial<KVNamespaceGetOptions<undefined>>): Promise<string | null>;
+  get(key: Key, type: "text"): Promise<string | null>;
+  get<ExpectedValue = unknown>(key: Key, type: "json"): Promise<ExpectedValue | null>;
+  get(key: Key, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+  get(key: Key, type: "stream"): Promise<ReadableStream | null>;
+  get(key: Key, options?: KVNamespaceGetOptions<"text">): Promise<string | null>;
+  get<ExpectedValue = unknown>(
+    key: Key,
+    options?: KVNamespaceGetOptions<"json">,
+  ): Promise<ExpectedValue | null>;
+  get(key: Key, options?: KVNamespaceGetOptions<"arrayBuffer">): Promise<ArrayBuffer | null>;
+  get(key: Key, options?: KVNamespaceGetOptions<"stream">): Promise<ReadableStream | null>;
+  get(key: Array<Key>, type: "text"): Promise<Map<string, string | null>>;
+  get<ExpectedValue = unknown>(
+    key: Array<Key>,
+    type: "json",
+  ): Promise<Map<string, ExpectedValue | null>>;
+  get(
+    key: Array<Key>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<Map<string, string | null>>;
+  get(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"text">,
+  ): Promise<Map<string, string | null>>;
+  get<ExpectedValue = unknown>(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"json">,
+  ): Promise<Map<string, ExpectedValue | null>>;
+  list<Metadata = unknown>(
+    options?: KVNamespaceListOptions,
+  ): Promise<KVNamespaceListResult<Metadata, Key>>;
+  put(
+    key: Key,
+    value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+    options?: KVNamespacePutOptions,
+  ): Promise<void>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    type: "text",
+  ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Key,
+    type: "json",
+  ): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    type: "arrayBuffer",
+  ): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    type: "stream",
+  ): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"text">,
+  ): Promise<KVNamespaceGetWithMetadataResult<string, Metadata>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"json">,
+  ): Promise<KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"arrayBuffer">,
+  ): Promise<KVNamespaceGetWithMetadataResult<ArrayBuffer, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Key,
+    options: KVNamespaceGetOptions<"stream">,
+  ): Promise<KVNamespaceGetWithMetadataResult<ReadableStream, Metadata>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Array<Key>,
+    type: "text",
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Array<Key>,
+    type: "json",
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Array<Key>,
+    options?: Partial<KVNamespaceGetOptions<undefined>>,
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
+  getWithMetadata<Metadata = unknown>(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"text">,
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<string, Metadata>>>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: Array<Key>,
+    options?: KVNamespaceGetOptions<"json">,
+  ): Promise<Map<string, KVNamespaceGetWithMetadataResult<ExpectedValue, Metadata>>>;
+  delete(key: Key): Promise<void>;
 }
 interface KVNamespaceListOptions {
-    limit?: number;
-    prefix?: (string | null);
-    cursor?: (string | null);
+  limit?: number;
+  prefix?: string | null;
+  cursor?: string | null;
 }
 interface KVNamespaceGetOptions<Type> {
-    type: Type;
-    cacheTtl?: number;
+  type: Type;
+  cacheTtl?: number;
 }
 interface KVNamespacePutOptions {
-    expiration?: number;
-    expirationTtl?: number;
-    metadata?: (any | null);
+  expiration?: number;
+  expirationTtl?: number;
+  metadata?: any | null;
 }
 interface KVNamespaceGetWithMetadataResult<Value, Metadata> {
-    value: Value | null;
-    metadata: Metadata | null;
-    cacheStatus: string | null;
+  value: Value | null;
+  metadata: Metadata | null;
+  cacheStatus: string | null;
 }
 type QueueContentType = "text" | "bytes" | "json" | "v8";
 interface Queue<Body = unknown> {
-    send(message: Body, options?: QueueSendOptions): Promise<void>;
-    sendBatch(messages: Iterable<MessageSendRequest<Body>>, options?: QueueSendBatchOptions): Promise<void>;
+  send(message: Body, options?: QueueSendOptions): Promise<void>;
+  sendBatch(
+    messages: Iterable<MessageSendRequest<Body>>,
+    options?: QueueSendBatchOptions,
+  ): Promise<void>;
 }
 interface QueueSendOptions {
-    contentType?: QueueContentType;
-    delaySeconds?: number;
+  contentType?: QueueContentType;
+  delaySeconds?: number;
 }
 interface QueueSendBatchOptions {
-    delaySeconds?: number;
+  delaySeconds?: number;
 }
 interface MessageSendRequest<Body = unknown> {
-    body: Body;
-    contentType?: QueueContentType;
-    delaySeconds?: number;
+  body: Body;
+  contentType?: QueueContentType;
+  delaySeconds?: number;
 }
 interface QueueRetryOptions {
-    delaySeconds?: number;
+  delaySeconds?: number;
 }
 interface Message<Body = unknown> {
-    readonly id: string;
-    readonly timestamp: Date;
-    readonly body: Body;
-    readonly attempts: number;
-    retry(options?: QueueRetryOptions): void;
-    ack(): void;
+  readonly id: string;
+  readonly timestamp: Date;
+  readonly body: Body;
+  readonly attempts: number;
+  retry(options?: QueueRetryOptions): void;
+  ack(): void;
 }
 interface QueueEvent<Body = unknown> extends ExtendableEvent {
-    readonly messages: readonly Message<Body>[];
-    readonly queue: string;
-    retryAll(options?: QueueRetryOptions): void;
-    ackAll(): void;
+  readonly messages: readonly Message<Body>[];
+  readonly queue: string;
+  retryAll(options?: QueueRetryOptions): void;
+  ackAll(): void;
 }
 interface MessageBatch<Body = unknown> {
-    readonly messages: readonly Message<Body>[];
-    readonly queue: string;
-    retryAll(options?: QueueRetryOptions): void;
-    ackAll(): void;
+  readonly messages: readonly Message<Body>[];
+  readonly queue: string;
+  retryAll(options?: QueueRetryOptions): void;
+  ackAll(): void;
 }
 interface R2Error extends Error {
-    readonly name: string;
-    readonly code: number;
-    readonly message: string;
-    readonly action: string;
-    readonly stack: any;
+  readonly name: string;
+  readonly code: number;
+  readonly message: string;
+  readonly action: string;
+  readonly stack: any;
 }
 interface R2ListOptions {
-    limit?: number;
-    prefix?: string;
-    cursor?: string;
-    delimiter?: string;
-    startAfter?: string;
-    include?: ("httpMetadata" | "customMetadata")[];
+  limit?: number;
+  prefix?: string;
+  cursor?: string;
+  delimiter?: string;
+  startAfter?: string;
+  include?: ("httpMetadata" | "customMetadata")[];
 }
 declare abstract class R2Bucket {
-    head(key: string): Promise<R2Object | null>;
-    get(key: string, options: R2GetOptions & {
-        onlyIf: R2Conditional | Headers;
-    }): Promise<R2ObjectBody | R2Object | null>;
-    get(key: string, options?: R2GetOptions): Promise<R2ObjectBody | null>;
-    put(key: string, value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob, options?: R2PutOptions & {
-        onlyIf: R2Conditional | Headers;
-    }): Promise<R2Object | null>;
-    put(key: string, value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob, options?: R2PutOptions): Promise<R2Object>;
-    createMultipartUpload(key: string, options?: R2MultipartOptions): Promise<R2MultipartUpload>;
-    resumeMultipartUpload(key: string, uploadId: string): R2MultipartUpload;
-    delete(keys: string | string[]): Promise<void>;
-    list(options?: R2ListOptions): Promise<R2Objects>;
+  head(key: string): Promise<R2Object | null>;
+  get(
+    key: string,
+    options: R2GetOptions & {
+      onlyIf: R2Conditional | Headers;
+    },
+  ): Promise<R2ObjectBody | R2Object | null>;
+  get(key: string, options?: R2GetOptions): Promise<R2ObjectBody | null>;
+  put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
+    options?: R2PutOptions & {
+      onlyIf: R2Conditional | Headers;
+    },
+  ): Promise<R2Object | null>;
+  put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
+    options?: R2PutOptions,
+  ): Promise<R2Object>;
+  createMultipartUpload(key: string, options?: R2MultipartOptions): Promise<R2MultipartUpload>;
+  resumeMultipartUpload(key: string, uploadId: string): R2MultipartUpload;
+  delete(keys: string | string[]): Promise<void>;
+  list(options?: R2ListOptions): Promise<R2Objects>;
 }
 interface R2MultipartUpload {
-    readonly key: string;
-    readonly uploadId: string;
-    uploadPart(partNumber: number, value: ReadableStream | (ArrayBuffer | ArrayBufferView) | string | Blob, options?: R2UploadPartOptions): Promise<R2UploadedPart>;
-    abort(): Promise<void>;
-    complete(uploadedParts: R2UploadedPart[]): Promise<R2Object>;
+  readonly key: string;
+  readonly uploadId: string;
+  uploadPart(
+    partNumber: number,
+    value: ReadableStream | (ArrayBuffer | ArrayBufferView) | string | Blob,
+    options?: R2UploadPartOptions,
+  ): Promise<R2UploadedPart>;
+  abort(): Promise<void>;
+  complete(uploadedParts: R2UploadedPart[]): Promise<R2Object>;
 }
 interface R2UploadedPart {
-    partNumber: number;
-    etag: string;
+  partNumber: number;
+  etag: string;
 }
 declare abstract class R2Object {
-    readonly key: string;
-    readonly version: string;
-    readonly size: number;
-    readonly etag: string;
-    readonly httpEtag: string;
-    readonly checksums: R2Checksums;
-    readonly uploaded: Date;
-    readonly httpMetadata?: R2HTTPMetadata;
-    readonly customMetadata?: Record<string, string>;
-    readonly range?: R2Range;
-    readonly storageClass: string;
-    readonly ssecKeyMd5?: string;
-    writeHttpMetadata(headers: Headers): void;
+  readonly key: string;
+  readonly version: string;
+  readonly size: number;
+  readonly etag: string;
+  readonly httpEtag: string;
+  readonly checksums: R2Checksums;
+  readonly uploaded: Date;
+  readonly httpMetadata?: R2HTTPMetadata;
+  readonly customMetadata?: Record<string, string>;
+  readonly range?: R2Range;
+  readonly storageClass: string;
+  readonly ssecKeyMd5?: string;
+  writeHttpMetadata(headers: Headers): void;
 }
 interface R2ObjectBody extends R2Object {
-    get body(): ReadableStream;
-    get bodyUsed(): boolean;
-    arrayBuffer(): Promise<ArrayBuffer>;
-    bytes(): Promise<Uint8Array>;
-    text(): Promise<string>;
-    json<T>(): Promise<T>;
-    blob(): Promise<Blob>;
+  get body(): ReadableStream;
+  get bodyUsed(): boolean;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  bytes(): Promise<Uint8Array>;
+  text(): Promise<string>;
+  json<T>(): Promise<T>;
+  blob(): Promise<Blob>;
 }
-type R2Range = {
-    offset: number;
-    length?: number;
-} | {
-    offset?: number;
-    length: number;
-} | {
-    suffix: number;
-};
+type R2Range =
+  | {
+      offset: number;
+      length?: number;
+    }
+  | {
+      offset?: number;
+      length: number;
+    }
+  | {
+      suffix: number;
+    };
 interface R2Conditional {
-    etagMatches?: string;
-    etagDoesNotMatch?: string;
-    uploadedBefore?: Date;
-    uploadedAfter?: Date;
-    secondsGranularity?: boolean;
+  etagMatches?: string;
+  etagDoesNotMatch?: string;
+  uploadedBefore?: Date;
+  uploadedAfter?: Date;
+  secondsGranularity?: boolean;
 }
 interface R2GetOptions {
-    onlyIf?: (R2Conditional | Headers);
-    range?: (R2Range | Headers);
-    ssecKey?: (ArrayBuffer | string);
+  onlyIf?: R2Conditional | Headers;
+  range?: R2Range | Headers;
+  ssecKey?: ArrayBuffer | string;
 }
 interface R2PutOptions {
-    onlyIf?: (R2Conditional | Headers);
-    httpMetadata?: (R2HTTPMetadata | Headers);
-    customMetadata?: Record<string, string>;
-    md5?: ((ArrayBuffer | ArrayBufferView) | string);
-    sha1?: ((ArrayBuffer | ArrayBufferView) | string);
-    sha256?: ((ArrayBuffer | ArrayBufferView) | string);
-    sha384?: ((ArrayBuffer | ArrayBufferView) | string);
-    sha512?: ((ArrayBuffer | ArrayBufferView) | string);
-    storageClass?: string;
-    ssecKey?: (ArrayBuffer | string);
+  onlyIf?: R2Conditional | Headers;
+  httpMetadata?: R2HTTPMetadata | Headers;
+  customMetadata?: Record<string, string>;
+  md5?: (ArrayBuffer | ArrayBufferView) | string;
+  sha1?: (ArrayBuffer | ArrayBufferView) | string;
+  sha256?: (ArrayBuffer | ArrayBufferView) | string;
+  sha384?: (ArrayBuffer | ArrayBufferView) | string;
+  sha512?: (ArrayBuffer | ArrayBufferView) | string;
+  storageClass?: string;
+  ssecKey?: ArrayBuffer | string;
 }
 interface R2MultipartOptions {
-    httpMetadata?: (R2HTTPMetadata | Headers);
-    customMetadata?: Record<string, string>;
-    storageClass?: string;
-    ssecKey?: (ArrayBuffer | string);
+  httpMetadata?: R2HTTPMetadata | Headers;
+  customMetadata?: Record<string, string>;
+  storageClass?: string;
+  ssecKey?: ArrayBuffer | string;
 }
 interface R2Checksums {
-    readonly md5?: ArrayBuffer;
-    readonly sha1?: ArrayBuffer;
-    readonly sha256?: ArrayBuffer;
-    readonly sha384?: ArrayBuffer;
-    readonly sha512?: ArrayBuffer;
-    toJSON(): R2StringChecksums;
+  readonly md5?: ArrayBuffer;
+  readonly sha1?: ArrayBuffer;
+  readonly sha256?: ArrayBuffer;
+  readonly sha384?: ArrayBuffer;
+  readonly sha512?: ArrayBuffer;
+  toJSON(): R2StringChecksums;
 }
 interface R2StringChecksums {
-    md5?: string;
-    sha1?: string;
-    sha256?: string;
-    sha384?: string;
-    sha512?: string;
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
 }
 interface R2HTTPMetadata {
-    contentType?: string;
-    contentLanguage?: string;
-    contentDisposition?: string;
-    contentEncoding?: string;
-    cacheControl?: string;
-    cacheExpiry?: Date;
+  contentType?: string;
+  contentLanguage?: string;
+  contentDisposition?: string;
+  contentEncoding?: string;
+  cacheControl?: string;
+  cacheExpiry?: Date;
 }
 type R2Objects = {
-    objects: R2Object[];
-    delimitedPrefixes: string[];
-} & ({
-    truncated: true;
-    cursor: string;
-} | {
-    truncated: false;
-});
+  objects: R2Object[];
+  delimitedPrefixes: string[];
+} & (
+  | {
+      truncated: true;
+      cursor: string;
+    }
+  | {
+      truncated: false;
+    }
+);
 interface R2UploadPartOptions {
-    ssecKey?: (ArrayBuffer | string);
+  ssecKey?: ArrayBuffer | string;
 }
 declare abstract class ScheduledEvent extends ExtendableEvent {
-    readonly scheduledTime: number;
-    readonly cron: string;
-    noRetry(): void;
+  readonly scheduledTime: number;
+  readonly cron: string;
+  noRetry(): void;
 }
 interface ScheduledController {
-    readonly scheduledTime: number;
-    readonly cron: string;
-    noRetry(): void;
+  readonly scheduledTime: number;
+  readonly cron: string;
+  noRetry(): void;
 }
 interface QueuingStrategy<T = any> {
-    highWaterMark?: (number | bigint);
-    size?: (chunk: T) => number | bigint;
+  highWaterMark?: number | bigint;
+  size?: (chunk: T) => number | bigint;
 }
 interface UnderlyingSink<W = any> {
-    type?: string;
-    start?: (controller: WritableStreamDefaultController) => void | Promise<void>;
-    write?: (chunk: W, controller: WritableStreamDefaultController) => void | Promise<void>;
-    abort?: (reason: any) => void | Promise<void>;
-    close?: () => void | Promise<void>;
+  type?: string;
+  start?: (controller: WritableStreamDefaultController) => void | Promise<void>;
+  write?: (chunk: W, controller: WritableStreamDefaultController) => void | Promise<void>;
+  abort?: (reason: any) => void | Promise<void>;
+  close?: () => void | Promise<void>;
 }
 interface UnderlyingByteSource {
-    type: "bytes";
-    autoAllocateChunkSize?: number;
-    start?: (controller: ReadableByteStreamController) => void | Promise<void>;
-    pull?: (controller: ReadableByteStreamController) => void | Promise<void>;
-    cancel?: (reason: any) => void | Promise<void>;
+  type: "bytes";
+  autoAllocateChunkSize?: number;
+  start?: (controller: ReadableByteStreamController) => void | Promise<void>;
+  pull?: (controller: ReadableByteStreamController) => void | Promise<void>;
+  cancel?: (reason: any) => void | Promise<void>;
 }
 interface UnderlyingSource<R = any> {
-    type?: "" | undefined;
-    start?: (controller: ReadableStreamDefaultController<R>) => void | Promise<void>;
-    pull?: (controller: ReadableStreamDefaultController<R>) => void | Promise<void>;
-    cancel?: (reason: any) => void | Promise<void>;
-    expectedLength?: (number | bigint);
+  type?: "" | undefined;
+  start?: (controller: ReadableStreamDefaultController<R>) => void | Promise<void>;
+  pull?: (controller: ReadableStreamDefaultController<R>) => void | Promise<void>;
+  cancel?: (reason: any) => void | Promise<void>;
+  expectedLength?: number | bigint;
 }
 interface Transformer<I = any, O = any> {
-    readableType?: string;
-    writableType?: string;
-    start?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
-    transform?: (chunk: I, controller: TransformStreamDefaultController<O>) => void | Promise<void>;
-    flush?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
-    cancel?: (reason: any) => void | Promise<void>;
-    expectedLength?: number;
+  readableType?: string;
+  writableType?: string;
+  start?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
+  transform?: (chunk: I, controller: TransformStreamDefaultController<O>) => void | Promise<void>;
+  flush?: (controller: TransformStreamDefaultController<O>) => void | Promise<void>;
+  cancel?: (reason: any) => void | Promise<void>;
+  expectedLength?: number;
 }
 interface StreamPipeOptions {
-    /**
-     * Pipes this readable stream to a given writable stream destination. The way in which the piping process behaves under various error conditions can be customized with a number of passed options. It returns a promise that fulfills when the piping process completes successfully, or rejects if any errors were encountered.
-     *
-     * Piping a stream will lock it for the duration of the pipe, preventing any other consumer from acquiring a reader.
-     *
-     * Errors and closures of the source and destination streams propagate as follows:
-     *
-     * An error in this source readable stream will abort destination, unless preventAbort is truthy. The returned promise will be rejected with the source's error, or with any error that occurs during aborting the destination.
-     *
-     * An error in destination will cancel this source readable stream, unless preventCancel is truthy. The returned promise will be rejected with the destination's error, or with any error that occurs during canceling the source.
-     *
-     * When this source readable stream closes, destination will be closed, unless preventClose is truthy. The returned promise will be fulfilled once this process completes, unless an error is encountered while closing the destination, in which case it will be rejected with that error.
-     *
-     * If destination starts out closed or closing, this source readable stream will be canceled, unless preventCancel is true. The returned promise will be rejected with an error indicating piping to a closed stream failed, or with any error that occurs during canceling the source.
-     *
-     * The signal option can be set to an AbortSignal to allow aborting an ongoing pipe operation via the corresponding AbortController. In this case, this source readable stream will be canceled, and destination aborted, unless the respective options preventCancel or preventAbort are set.
-     */
-    preventClose?: boolean;
-    preventAbort?: boolean;
-    preventCancel?: boolean;
-    signal?: AbortSignal;
+  /**
+   * Pipes this readable stream to a given writable stream destination. The way in which the piping process behaves under various error conditions can be customized with a number of passed options. It returns a promise that fulfills when the piping process completes successfully, or rejects if any errors were encountered.
+   *
+   * Piping a stream will lock it for the duration of the pipe, preventing any other consumer from acquiring a reader.
+   *
+   * Errors and closures of the source and destination streams propagate as follows:
+   *
+   * An error in this source readable stream will abort destination, unless preventAbort is truthy. The returned promise will be rejected with the source's error, or with any error that occurs during aborting the destination.
+   *
+   * An error in destination will cancel this source readable stream, unless preventCancel is truthy. The returned promise will be rejected with the destination's error, or with any error that occurs during canceling the source.
+   *
+   * When this source readable stream closes, destination will be closed, unless preventClose is truthy. The returned promise will be fulfilled once this process completes, unless an error is encountered while closing the destination, in which case it will be rejected with that error.
+   *
+   * If destination starts out closed or closing, this source readable stream will be canceled, unless preventCancel is true. The returned promise will be rejected with an error indicating piping to a closed stream failed, or with any error that occurs during canceling the source.
+   *
+   * The signal option can be set to an AbortSignal to allow aborting an ongoing pipe operation via the corresponding AbortController. In this case, this source readable stream will be canceled, and destination aborted, unless the respective options preventCancel or preventAbort are set.
+   */
+  preventClose?: boolean;
+  preventAbort?: boolean;
+  preventCancel?: boolean;
+  signal?: AbortSignal;
 }
-type ReadableStreamReadResult<R = any> = {
-    done: false;
-    value: R;
-} | {
-    done: true;
-    value?: undefined;
-};
+type ReadableStreamReadResult<R = any> =
+  | {
+      done: false;
+      value: R;
+    }
+  | {
+      done: true;
+      value?: undefined;
+    };
 /**
  * This Streams API interface represents a readable stream of byte data. The Fetch API offers a concrete instance of a ReadableStream through the body property of a Response object.
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream)
  */
 interface ReadableStream<R = any> {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/locked) */
-    get locked(): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel) */
-    cancel(reason?: any): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader) */
-    getReader(): ReadableStreamDefaultReader<R>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader) */
-    getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeThrough) */
-    pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeTo) */
-    pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee) */
-    tee(): [
-        ReadableStream<R>,
-        ReadableStream<R>
-    ];
-    values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
-    [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/locked) */
+  get locked(): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel) */
+  cancel(reason?: any): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader) */
+  getReader(): ReadableStreamDefaultReader<R>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader) */
+  getReader(options: ReadableStreamGetReaderOptions): ReadableStreamBYOBReader;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeThrough) */
+  pipeThrough<T>(
+    transform: ReadableWritablePair<T, R>,
+    options?: StreamPipeOptions,
+  ): ReadableStream<T>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeTo) */
+  pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee) */
+  tee(): [ReadableStream<R>, ReadableStream<R>];
+  values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
+  [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<R>;
 }
 /**
  * This Streams API interface represents a readable stream of byte data. The Fetch API offers a concrete instance of a ReadableStream through the body property of a Response object.
@@ -1801,75 +2102,84 @@ interface ReadableStream<R = any> {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStream)
  */
 declare const ReadableStream: {
-    prototype: ReadableStream;
-    new (underlyingSource: UnderlyingByteSource, strategy?: QueuingStrategy<Uint8Array>): ReadableStream<Uint8Array>;
-    new <R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
+  prototype: ReadableStream;
+  new (
+    underlyingSource: UnderlyingByteSource,
+    strategy?: QueuingStrategy<Uint8Array>,
+  ): ReadableStream<Uint8Array>;
+  new <R = any>(
+    underlyingSource?: UnderlyingSource<R>,
+    strategy?: QueuingStrategy<R>,
+  ): ReadableStream<R>;
 };
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader) */
 declare class ReadableStreamDefaultReader<R = any> {
-    constructor(stream: ReadableStream);
-    get closed(): Promise<void>;
-    cancel(reason?: any): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/read) */
-    read(): Promise<ReadableStreamReadResult<R>>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/releaseLock) */
-    releaseLock(): void;
+  constructor(stream: ReadableStream);
+  get closed(): Promise<void>;
+  cancel(reason?: any): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/read) */
+  read(): Promise<ReadableStreamReadResult<R>>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/releaseLock) */
+  releaseLock(): void;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader) */
 declare class ReadableStreamBYOBReader {
-    constructor(stream: ReadableStream);
-    get closed(): Promise<void>;
-    cancel(reason?: any): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/read) */
-    read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/releaseLock) */
-    releaseLock(): void;
-    readAtLeast<T extends ArrayBufferView>(minElements: number, view: T): Promise<ReadableStreamReadResult<T>>;
+  constructor(stream: ReadableStream);
+  get closed(): Promise<void>;
+  cancel(reason?: any): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/read) */
+  read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBReader/releaseLock) */
+  releaseLock(): void;
+  readAtLeast<T extends ArrayBufferView>(
+    minElements: number,
+    view: T,
+  ): Promise<ReadableStreamReadResult<T>>;
 }
 interface ReadableStreamBYOBReaderReadableStreamBYOBReaderReadOptions {
-    min?: number;
+  min?: number;
 }
 interface ReadableStreamGetReaderOptions {
-    /**
-     * Creates a ReadableStreamBYOBReader and locks the stream to the new reader.
-     *
-     * This call behaves the same way as the no-argument variant, except that it only works on readable byte streams, i.e. streams which were constructed specifically with the ability to handle "bring your own buffer" reading. The returned BYOB reader provides the ability to directly read individual chunks from the stream via its read() method, into developer-supplied buffers, allowing more precise control over allocation.
-     */
-    mode: "byob";
+  /**
+   * Creates a ReadableStreamBYOBReader and locks the stream to the new reader.
+   *
+   * This call behaves the same way as the no-argument variant, except that it only works on readable byte streams, i.e. streams which were constructed specifically with the ability to handle "bring your own buffer" reading. The returned BYOB reader provides the ability to directly read individual chunks from the stream via its read() method, into developer-supplied buffers, allowing more precise control over allocation.
+   */
+  mode: "byob";
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest) */
 declare abstract class ReadableStreamBYOBRequest {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/view) */
-    get view(): Uint8Array | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respond) */
-    respond(bytesWritten: number): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView) */
-    respondWithNewView(view: ArrayBuffer | ArrayBufferView): void;
-    get atLeast(): number | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/view) */
+  get view(): Uint8Array | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respond) */
+  respond(bytesWritten: number): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView) */
+  respondWithNewView(view: ArrayBuffer | ArrayBufferView): void;
+  get atLeast(): number | null;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController) */
 declare abstract class ReadableStreamDefaultController<R = any> {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/desiredSize) */
-    get desiredSize(): number | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/close) */
-    close(): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/enqueue) */
-    enqueue(chunk?: R): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/error) */
-    error(reason: any): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/desiredSize) */
+  get desiredSize(): number | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/close) */
+  close(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/enqueue) */
+  enqueue(chunk?: R): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultController/error) */
+  error(reason: any): void;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController) */
 declare abstract class ReadableByteStreamController {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/byobRequest) */
-    get byobRequest(): ReadableStreamBYOBRequest | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/desiredSize) */
-    get desiredSize(): number | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/close) */
-    close(): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/enqueue) */
-    enqueue(chunk: ArrayBuffer | ArrayBufferView): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/error) */
-    error(reason: any): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/byobRequest) */
+  get byobRequest(): ReadableStreamBYOBRequest | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/desiredSize) */
+  get desiredSize(): number | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/close) */
+  close(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/enqueue) */
+  enqueue(chunk: ArrayBuffer | ArrayBufferView): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ReadableByteStreamController/error) */
+  error(reason: any): void;
 }
 /**
  * This Streams API interface represents a controller allowing control of a WritableStream's state. When constructing a WritableStream, the underlying sink is given a corresponding WritableStreamDefaultController instance to manipulate.
@@ -1877,30 +2187,30 @@ declare abstract class ReadableByteStreamController {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController)
  */
 declare abstract class WritableStreamDefaultController {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/signal) */
-    get signal(): AbortSignal;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/error) */
-    error(reason?: any): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/signal) */
+  get signal(): AbortSignal;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/error) */
+  error(reason?: any): void;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController) */
 declare abstract class TransformStreamDefaultController<O = any> {
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/desiredSize) */
-    get desiredSize(): number | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/enqueue) */
-    enqueue(chunk?: O): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/error) */
-    error(reason: any): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/terminate) */
-    terminate(): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/desiredSize) */
+  get desiredSize(): number | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/enqueue) */
+  enqueue(chunk?: O): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/error) */
+  error(reason: any): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController/terminate) */
+  terminate(): void;
 }
 interface ReadableWritablePair<R = any, W = any> {
-    /**
-     * Provides a convenient, chainable way of piping this readable stream through a transform stream (or any other { writable, readable } pair). It simply pipes the stream into the writable side of the supplied pair, and returns the readable side for further use.
-     *
-     * Piping a stream will lock it for the duration of the pipe, preventing any other consumer from acquiring a reader.
-     */
-    writable: WritableStream<W>;
-    readable: ReadableStream<R>;
+  /**
+   * Provides a convenient, chainable way of piping this readable stream through a transform stream (or any other { writable, readable } pair). It simply pipes the stream into the writable side of the supplied pair, and returns the readable side for further use.
+   *
+   * Piping a stream will lock it for the duration of the pipe, preventing any other consumer from acquiring a reader.
+   */
+  writable: WritableStream<W>;
+  readable: ReadableStream<R>;
 }
 /**
  * This Streams API interface provides a standard abstraction for writing streaming data to a destination, known as a sink. This object comes with built-in backpressure and queuing.
@@ -1908,15 +2218,15 @@ interface ReadableWritablePair<R = any, W = any> {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream)
  */
 declare class WritableStream<W = any> {
-    constructor(underlyingSink?: UnderlyingSink, queuingStrategy?: QueuingStrategy);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/locked) */
-    get locked(): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/abort) */
-    abort(reason?: any): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/close) */
-    close(): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter) */
-    getWriter(): WritableStreamDefaultWriter<W>;
+  constructor(underlyingSink?: UnderlyingSink, queuingStrategy?: QueuingStrategy);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/locked) */
+  get locked(): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/abort) */
+  abort(reason?: any): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/close) */
+  close(): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStream/getWriter) */
+  getWriter(): WritableStreamDefaultWriter<W>;
 }
 /**
  * This Streams API interface is the object returned by WritableStream.getWriter() and once created locks the < writer to the WritableStream ensuring that no other streams can write to the underlying sink.
@@ -1924,65 +2234,78 @@ declare class WritableStream<W = any> {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter)
  */
 declare class WritableStreamDefaultWriter<W = any> {
-    constructor(stream: WritableStream);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/closed) */
-    get closed(): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/ready) */
-    get ready(): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/desiredSize) */
-    get desiredSize(): number | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/abort) */
-    abort(reason?: any): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/close) */
-    close(): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/write) */
-    write(chunk?: W): Promise<void>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/releaseLock) */
-    releaseLock(): void;
+  constructor(stream: WritableStream);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/closed) */
+  get closed(): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/ready) */
+  get ready(): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/desiredSize) */
+  get desiredSize(): number | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/abort) */
+  abort(reason?: any): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/close) */
+  close(): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/write) */
+  write(chunk?: W): Promise<void>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter/releaseLock) */
+  releaseLock(): void;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStream) */
 declare class TransformStream<I = any, O = any> {
-    constructor(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStream/readable) */
-    get readable(): ReadableStream<O>;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStream/writable) */
-    get writable(): WritableStream<I>;
+  constructor(
+    transformer?: Transformer<I, O>,
+    writableStrategy?: QueuingStrategy<I>,
+    readableStrategy?: QueuingStrategy<O>,
+  );
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStream/readable) */
+  get readable(): ReadableStream<O>;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TransformStream/writable) */
+  get writable(): WritableStream<I>;
 }
 declare class FixedLengthStream extends IdentityTransformStream {
-    constructor(expectedLength: number | bigint, queuingStrategy?: IdentityTransformStreamQueuingStrategy);
+  constructor(
+    expectedLength: number | bigint,
+    queuingStrategy?: IdentityTransformStreamQueuingStrategy,
+  );
 }
-declare class IdentityTransformStream extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> {
-    constructor(queuingStrategy?: IdentityTransformStreamQueuingStrategy);
+declare class IdentityTransformStream extends TransformStream<
+  ArrayBuffer | ArrayBufferView,
+  Uint8Array
+> {
+  constructor(queuingStrategy?: IdentityTransformStreamQueuingStrategy);
 }
 interface IdentityTransformStreamQueuingStrategy {
-    highWaterMark?: (number | bigint);
+  highWaterMark?: number | bigint;
 }
 interface ReadableStreamValuesOptions {
-    preventCancel?: boolean;
+  preventCancel?: boolean;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CompressionStream) */
 declare class CompressionStream extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> {
-    constructor(format: "gzip" | "deflate" | "deflate-raw");
+  constructor(format: "gzip" | "deflate" | "deflate-raw");
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/DecompressionStream) */
-declare class DecompressionStream extends TransformStream<ArrayBuffer | ArrayBufferView, Uint8Array> {
-    constructor(format: "gzip" | "deflate" | "deflate-raw");
+declare class DecompressionStream extends TransformStream<
+  ArrayBuffer | ArrayBufferView,
+  Uint8Array
+> {
+  constructor(format: "gzip" | "deflate" | "deflate-raw");
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextEncoderStream) */
 declare class TextEncoderStream extends TransformStream<string, Uint8Array> {
-    constructor();
-    get encoding(): string;
+  constructor();
+  get encoding(): string;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/TextDecoderStream) */
 declare class TextDecoderStream extends TransformStream<ArrayBuffer | ArrayBufferView, string> {
-    constructor(label?: string, options?: TextDecoderStreamTextDecoderStreamInit);
-    get encoding(): string;
-    get fatal(): boolean;
-    get ignoreBOM(): boolean;
+  constructor(label?: string, options?: TextDecoderStreamTextDecoderStreamInit);
+  get encoding(): string;
+  get fatal(): boolean;
+  get ignoreBOM(): boolean;
 }
 interface TextDecoderStreamTextDecoderStreamInit {
-    fatal?: boolean;
-    ignoreBOM?: boolean;
+  fatal?: boolean;
+  ignoreBOM?: boolean;
 }
 /**
  * This Streams API interface provides a built-in byte length queuing strategy that can be used when constructing streams.
@@ -1990,11 +2313,11 @@ interface TextDecoderStreamTextDecoderStreamInit {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy)
  */
 declare class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferView> {
-    constructor(init: QueuingStrategyInit);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/highWaterMark) */
-    get highWaterMark(): number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/size) */
-    get size(): (chunk?: any) => number;
+  constructor(init: QueuingStrategyInit);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/highWaterMark) */
+  get highWaterMark(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy/size) */
+  get size(): (chunk?: any) => number;
 }
 /**
  * This Streams API interface provides a built-in byte length queuing strategy that can be used when constructing streams.
@@ -2002,124 +2325,138 @@ declare class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferVi
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy)
  */
 declare class CountQueuingStrategy implements QueuingStrategy {
-    constructor(init: QueuingStrategyInit);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy/highWaterMark) */
-    get highWaterMark(): number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy/size) */
-    get size(): (chunk?: any) => number;
+  constructor(init: QueuingStrategyInit);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy/highWaterMark) */
+  get highWaterMark(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy/size) */
+  get size(): (chunk?: any) => number;
 }
 interface QueuingStrategyInit {
-    /**
-     * Creates a new ByteLengthQueuingStrategy with the provided high water mark.
-     *
-     * Note that the provided high water mark will not be validated ahead of time. Instead, if it is negative, NaN, or not a number, the resulting ByteLengthQueuingStrategy will cause the corresponding stream constructor to throw.
-     */
-    highWaterMark: number;
+  /**
+   * Creates a new ByteLengthQueuingStrategy with the provided high water mark.
+   *
+   * Note that the provided high water mark will not be validated ahead of time. Instead, if it is negative, NaN, or not a number, the resulting ByteLengthQueuingStrategy will cause the corresponding stream constructor to throw.
+   */
+  highWaterMark: number;
 }
 interface ScriptVersion {
-    id?: string;
-    tag?: string;
-    message?: string;
+  id?: string;
+  tag?: string;
+  message?: string;
 }
 declare abstract class TailEvent extends ExtendableEvent {
-    readonly events: TraceItem[];
-    readonly traces: TraceItem[];
+  readonly events: TraceItem[];
+  readonly traces: TraceItem[];
 }
 interface TraceItem {
-    readonly event: (TraceItemFetchEventInfo | TraceItemJsRpcEventInfo | TraceItemScheduledEventInfo | TraceItemAlarmEventInfo | TraceItemQueueEventInfo | TraceItemEmailEventInfo | TraceItemTailEventInfo | TraceItemCustomEventInfo | TraceItemHibernatableWebSocketEventInfo) | null;
-    readonly eventTimestamp: number | null;
-    readonly logs: TraceLog[];
-    readonly exceptions: TraceException[];
-    readonly diagnosticsChannelEvents: TraceDiagnosticChannelEvent[];
-    readonly scriptName: string | null;
-    readonly entrypoint?: string;
-    readonly scriptVersion?: ScriptVersion;
-    readonly dispatchNamespace?: string;
-    readonly scriptTags?: string[];
-    readonly durableObjectId?: string;
-    readonly outcome: string;
-    readonly executionModel: string;
-    readonly truncated: boolean;
-    readonly cpuTime: number;
-    readonly wallTime: number;
+  readonly event:
+    | (
+        | TraceItemFetchEventInfo
+        | TraceItemJsRpcEventInfo
+        | TraceItemScheduledEventInfo
+        | TraceItemAlarmEventInfo
+        | TraceItemQueueEventInfo
+        | TraceItemEmailEventInfo
+        | TraceItemTailEventInfo
+        | TraceItemCustomEventInfo
+        | TraceItemHibernatableWebSocketEventInfo
+      )
+    | null;
+  readonly eventTimestamp: number | null;
+  readonly logs: TraceLog[];
+  readonly exceptions: TraceException[];
+  readonly diagnosticsChannelEvents: TraceDiagnosticChannelEvent[];
+  readonly scriptName: string | null;
+  readonly entrypoint?: string;
+  readonly scriptVersion?: ScriptVersion;
+  readonly dispatchNamespace?: string;
+  readonly scriptTags?: string[];
+  readonly durableObjectId?: string;
+  readonly outcome: string;
+  readonly executionModel: string;
+  readonly truncated: boolean;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface TraceItemAlarmEventInfo {
-    readonly scheduledTime: Date;
+  readonly scheduledTime: Date;
 }
-interface TraceItemCustomEventInfo {
-}
+interface TraceItemCustomEventInfo {}
 interface TraceItemScheduledEventInfo {
-    readonly scheduledTime: number;
-    readonly cron: string;
+  readonly scheduledTime: number;
+  readonly cron: string;
 }
 interface TraceItemQueueEventInfo {
-    readonly queue: string;
-    readonly batchSize: number;
+  readonly queue: string;
+  readonly batchSize: number;
 }
 interface TraceItemEmailEventInfo {
-    readonly mailFrom: string;
-    readonly rcptTo: string;
-    readonly rawSize: number;
+  readonly mailFrom: string;
+  readonly rcptTo: string;
+  readonly rawSize: number;
 }
 interface TraceItemTailEventInfo {
-    readonly consumedEvents: TraceItemTailEventInfoTailItem[];
+  readonly consumedEvents: TraceItemTailEventInfoTailItem[];
 }
 interface TraceItemTailEventInfoTailItem {
-    readonly scriptName: string | null;
+  readonly scriptName: string | null;
 }
 interface TraceItemFetchEventInfo {
-    readonly response?: TraceItemFetchEventInfoResponse;
-    readonly request: TraceItemFetchEventInfoRequest;
+  readonly response?: TraceItemFetchEventInfoResponse;
+  readonly request: TraceItemFetchEventInfoRequest;
 }
 interface TraceItemFetchEventInfoRequest {
-    readonly cf?: any;
-    readonly headers: Record<string, string>;
-    readonly method: string;
-    readonly url: string;
-    getUnredacted(): TraceItemFetchEventInfoRequest;
+  readonly cf?: any;
+  readonly headers: Record<string, string>;
+  readonly method: string;
+  readonly url: string;
+  getUnredacted(): TraceItemFetchEventInfoRequest;
 }
 interface TraceItemFetchEventInfoResponse {
-    readonly status: number;
+  readonly status: number;
 }
 interface TraceItemJsRpcEventInfo {
-    readonly rpcMethod: string;
+  readonly rpcMethod: string;
 }
 interface TraceItemHibernatableWebSocketEventInfo {
-    readonly getWebSocketEvent: TraceItemHibernatableWebSocketEventInfoMessage | TraceItemHibernatableWebSocketEventInfoClose | TraceItemHibernatableWebSocketEventInfoError;
+  readonly getWebSocketEvent:
+    | TraceItemHibernatableWebSocketEventInfoMessage
+    | TraceItemHibernatableWebSocketEventInfoClose
+    | TraceItemHibernatableWebSocketEventInfoError;
 }
 interface TraceItemHibernatableWebSocketEventInfoMessage {
-    readonly webSocketEventType: string;
+  readonly webSocketEventType: string;
 }
 interface TraceItemHibernatableWebSocketEventInfoClose {
-    readonly webSocketEventType: string;
-    readonly code: number;
-    readonly wasClean: boolean;
+  readonly webSocketEventType: string;
+  readonly code: number;
+  readonly wasClean: boolean;
 }
 interface TraceItemHibernatableWebSocketEventInfoError {
-    readonly webSocketEventType: string;
+  readonly webSocketEventType: string;
 }
 interface TraceLog {
-    readonly timestamp: number;
-    readonly level: string;
-    readonly message: any;
+  readonly timestamp: number;
+  readonly level: string;
+  readonly message: any;
 }
 interface TraceException {
-    readonly timestamp: number;
-    readonly message: string;
-    readonly name: string;
-    readonly stack?: string;
+  readonly timestamp: number;
+  readonly message: string;
+  readonly name: string;
+  readonly stack?: string;
 }
 interface TraceDiagnosticChannelEvent {
-    readonly timestamp: number;
-    readonly channel: string;
-    readonly message: any;
+  readonly timestamp: number;
+  readonly channel: string;
+  readonly message: any;
 }
 interface TraceMetrics {
-    readonly cpuTime: number;
-    readonly wallTime: number;
+  readonly cpuTime: number;
+  readonly wallTime: number;
 }
 interface UnsafeTraceMetrics {
-    fromTrace(item: TraceItem): TraceMetrics;
+  fromTrace(item: TraceItem): TraceMetrics;
 }
 /**
  * The URL interface represents an object providing static methods used for creating object URLs.
@@ -2127,165 +2464,166 @@ interface UnsafeTraceMetrics {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)
  */
 declare class URL {
-    constructor(url: string | URL, base?: string | URL);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/origin) */
-    get origin(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/href) */
-    get href(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/href) */
-    set href(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/protocol) */
-    get protocol(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/protocol) */
-    set protocol(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/username) */
-    get username(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/username) */
-    set username(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/password) */
-    get password(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/password) */
-    set password(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/host) */
-    get host(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/host) */
-    set host(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hostname) */
-    get hostname(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hostname) */
-    set hostname(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/port) */
-    get port(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/port) */
-    set port(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/pathname) */
-    get pathname(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/pathname) */
-    set pathname(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/search) */
-    get search(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/search) */
-    set search(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hash) */
-    get hash(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hash) */
-    set hash(value: string);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/searchParams) */
-    get searchParams(): URLSearchParams;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/toJSON) */
-    toJSON(): string;
-    /*function toString() { [native code] }*/
-    toString(): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
-    static canParse(url: string, base?: string): boolean;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
-    static parse(url: string, base?: string): URL | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
-    static createObjectURL(object: File | Blob): string;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static) */
-    static revokeObjectURL(object_url: string): void;
+  constructor(url: string | URL, base?: string | URL);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/origin) */
+  get origin(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/href) */
+  get href(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/href) */
+  set href(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/protocol) */
+  get protocol(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/protocol) */
+  set protocol(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/username) */
+  get username(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/username) */
+  set username(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/password) */
+  get password(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/password) */
+  set password(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/host) */
+  get host(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/host) */
+  set host(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hostname) */
+  get hostname(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hostname) */
+  set hostname(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/port) */
+  get port(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/port) */
+  set port(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/pathname) */
+  get pathname(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/pathname) */
+  set pathname(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/search) */
+  get search(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/search) */
+  set search(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hash) */
+  get hash(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/hash) */
+  set hash(value: string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/searchParams) */
+  get searchParams(): URLSearchParams;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/toJSON) */
+  toJSON(): string;
+  /*function toString() { [native code] }*/
+  toString(): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
+  static canParse(url: string, base?: string): boolean;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
+  static parse(url: string, base?: string): URL | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
+  static createObjectURL(object: File | Blob): string;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static) */
+  static revokeObjectURL(object_url: string): void;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams) */
 declare class URLSearchParams {
-    constructor(init?: (Iterable<Iterable<string>> | Record<string, string> | string));
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/size) */
-    get size(): number;
-    /**
-     * Appends a specified key/value pair as a new search parameter.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/append)
-     */
-    append(name: string, value: string): void;
-    /**
-     * Deletes the given search parameter, and its associated value, from the list of all search parameters.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete)
-     */
-    delete(name: string, value?: string): void;
-    /**
-     * Returns the first value associated to the given search parameter.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/get)
-     */
-    get(name: string): string | null;
-    /**
-     * Returns all the values association with a given search parameter.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll)
-     */
-    getAll(name: string): string[];
-    /**
-     * Returns a Boolean indicating if such a search parameter exists.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/has)
-     */
-    has(name: string, value?: string): boolean;
-    /**
-     * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/set)
-     */
-    set(name: string, value: string): void;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/sort) */
-    sort(): void;
-    /* Returns an array of key, value pairs for every entry in the search params. */
-    entries(): IterableIterator<[
-        key: string,
-        value: string
-    ]>;
-    /* Returns a list of keys in the search params. */
-    keys(): IterableIterator<string>;
-    /* Returns a list of values in the search params. */
-    values(): IterableIterator<string>;
-    forEach<This = unknown>(callback: (this: This, value: string, key: string, parent: URLSearchParams) => void, thisArg?: This): void;
-    /*function toString() { [native code] } Returns a string containing a query string suitable for use in a URL. Does not include the question mark. */
-    toString(): string;
-    [Symbol.iterator](): IterableIterator<[
-        key: string,
-        value: string
-    ]>;
+  constructor(init?: Iterable<Iterable<string>> | Record<string, string> | string);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/size) */
+  get size(): number;
+  /**
+   * Appends a specified key/value pair as a new search parameter.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/append)
+   */
+  append(name: string, value: string): void;
+  /**
+   * Deletes the given search parameter, and its associated value, from the list of all search parameters.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete)
+   */
+  delete(name: string, value?: string): void;
+  /**
+   * Returns the first value associated to the given search parameter.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/get)
+   */
+  get(name: string): string | null;
+  /**
+   * Returns all the values association with a given search parameter.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll)
+   */
+  getAll(name: string): string[];
+  /**
+   * Returns a Boolean indicating if such a search parameter exists.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/has)
+   */
+  has(name: string, value?: string): boolean;
+  /**
+   * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/set)
+   */
+  set(name: string, value: string): void;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/sort) */
+  sort(): void;
+  /* Returns an array of key, value pairs for every entry in the search params. */
+  entries(): IterableIterator<[key: string, value: string]>;
+  /* Returns a list of keys in the search params. */
+  keys(): IterableIterator<string>;
+  /* Returns a list of values in the search params. */
+  values(): IterableIterator<string>;
+  forEach<This = unknown>(
+    callback: (this: This, value: string, key: string, parent: URLSearchParams) => void,
+    thisArg?: This,
+  ): void;
+  /*function toString() { [native code] } Returns a string containing a query string suitable for use in a URL. Does not include the question mark. */
+  toString(): string;
+  [Symbol.iterator](): IterableIterator<[key: string, value: string]>;
 }
 declare class URLPattern {
-    constructor(input?: (string | URLPatternInit), baseURL?: (string | URLPatternOptions), patternOptions?: URLPatternOptions);
-    get protocol(): string;
-    get username(): string;
-    get password(): string;
-    get hostname(): string;
-    get port(): string;
-    get pathname(): string;
-    get search(): string;
-    get hash(): string;
-    test(input?: (string | URLPatternInit), baseURL?: string): boolean;
-    exec(input?: (string | URLPatternInit), baseURL?: string): URLPatternResult | null;
+  constructor(
+    input?: string | URLPatternInit,
+    baseURL?: string | URLPatternOptions,
+    patternOptions?: URLPatternOptions,
+  );
+  get protocol(): string;
+  get username(): string;
+  get password(): string;
+  get hostname(): string;
+  get port(): string;
+  get pathname(): string;
+  get search(): string;
+  get hash(): string;
+  test(input?: string | URLPatternInit, baseURL?: string): boolean;
+  exec(input?: string | URLPatternInit, baseURL?: string): URLPatternResult | null;
 }
 interface URLPatternInit {
-    protocol?: string;
-    username?: string;
-    password?: string;
-    hostname?: string;
-    port?: string;
-    pathname?: string;
-    search?: string;
-    hash?: string;
-    baseURL?: string;
+  protocol?: string;
+  username?: string;
+  password?: string;
+  hostname?: string;
+  port?: string;
+  pathname?: string;
+  search?: string;
+  hash?: string;
+  baseURL?: string;
 }
 interface URLPatternComponentResult {
-    input: string;
-    groups: Record<string, string>;
+  input: string;
+  groups: Record<string, string>;
 }
 interface URLPatternResult {
-    inputs: (string | URLPatternInit)[];
-    protocol: URLPatternComponentResult;
-    username: URLPatternComponentResult;
-    password: URLPatternComponentResult;
-    hostname: URLPatternComponentResult;
-    port: URLPatternComponentResult;
-    pathname: URLPatternComponentResult;
-    search: URLPatternComponentResult;
-    hash: URLPatternComponentResult;
+  inputs: (string | URLPatternInit)[];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
 }
 interface URLPatternOptions {
-    ignoreCase?: boolean;
+  ignoreCase?: boolean;
 }
 /**
  * A CloseEvent is sent to clients using WebSockets when the connection is closed. This is delivered to the listener indicated by the WebSocket object's onclose attribute.
@@ -2293,36 +2631,36 @@ interface URLPatternOptions {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent)
  */
 declare class CloseEvent extends Event {
-    constructor(type: string, initializer?: CloseEventInit);
-    /**
-     * Returns the WebSocket connection close code provided by the server.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent/code)
-     */
-    readonly code: number;
-    /**
-     * Returns the WebSocket connection close reason provided by the server.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent/reason)
-     */
-    readonly reason: string;
-    /**
-     * Returns true if the connection closed cleanly; false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent/wasClean)
-     */
-    readonly wasClean: boolean;
+  constructor(type: string, initializer?: CloseEventInit);
+  /**
+   * Returns the WebSocket connection close code provided by the server.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent/code)
+   */
+  readonly code: number;
+  /**
+   * Returns the WebSocket connection close reason provided by the server.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent/reason)
+   */
+  readonly reason: string;
+  /**
+   * Returns true if the connection closed cleanly; false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CloseEvent/wasClean)
+   */
+  readonly wasClean: boolean;
 }
 interface CloseEventInit {
-    code?: number;
-    reason?: string;
-    wasClean?: boolean;
+  code?: number;
+  reason?: string;
+  wasClean?: boolean;
 }
 type WebSocketEventMap = {
-    close: CloseEvent;
-    message: MessageEvent;
-    open: Event;
-    error: ErrorEvent;
+  close: CloseEvent;
+  message: MessageEvent;
+  open: Event;
+  error: ErrorEvent;
 };
 /**
  * Provides the API for creating and managing a WebSocket connection to a server, as well as for sending and receiving data on the connection.
@@ -2330,16 +2668,16 @@ type WebSocketEventMap = {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket)
  */
 declare var WebSocket: {
-    prototype: WebSocket;
-    new (url: string, protocols?: (string[] | string)): WebSocket;
-    readonly READY_STATE_CONNECTING: number;
-    readonly CONNECTING: number;
-    readonly READY_STATE_OPEN: number;
-    readonly OPEN: number;
-    readonly READY_STATE_CLOSING: number;
-    readonly CLOSING: number;
-    readonly READY_STATE_CLOSED: number;
-    readonly CLOSED: number;
+  prototype: WebSocket;
+  new (url: string, protocols?: string[] | string): WebSocket;
+  readonly READY_STATE_CONNECTING: number;
+  readonly CONNECTING: number;
+  readonly READY_STATE_OPEN: number;
+  readonly OPEN: number;
+  readonly READY_STATE_CLOSING: number;
+  readonly CLOSING: number;
+  readonly READY_STATE_CLOSED: number;
+  readonly CLOSED: number;
 };
 /**
  * Provides the API for creating and managing a WebSocket connection to a server, as well as for sending and receiving data on the connection.
@@ -2347,163 +2685,167 @@ declare var WebSocket: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket)
  */
 interface WebSocket extends EventTarget<WebSocketEventMap> {
-    accept(): void;
-    /**
-     * Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
-     */
-    send(message: (ArrayBuffer | ArrayBufferView) | string): void;
-    /**
-     * Closes the WebSocket connection, optionally using code as the the WebSocket connection close code and reason as the the WebSocket connection close reason.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/close)
-     */
-    close(code?: number, reason?: string): void;
-    serializeAttachment(attachment: any): void;
-    deserializeAttachment(): any | null;
-    /**
-     * Returns the state of the WebSocket object's connection. It can have the values described below.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/readyState)
-     */
-    readyState: number;
-    /**
-     * Returns the URL that was used to establish the WebSocket connection.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/url)
-     */
-    url: string | null;
-    /**
-     * Returns the subprotocol selected by the server, if any. It can be used in conjunction with the array form of the constructor's second argument to perform subprotocol negotiation.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/protocol)
-     */
-    protocol: string | null;
-    /**
-     * Returns the extensions selected by the server, if any.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/extensions)
-     */
-    extensions: string | null;
+  accept(): void;
+  /**
+   * Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/send)
+   */
+  send(message: (ArrayBuffer | ArrayBufferView) | string): void;
+  /**
+   * Closes the WebSocket connection, optionally using code as the the WebSocket connection close code and reason as the the WebSocket connection close reason.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/close)
+   */
+  close(code?: number, reason?: string): void;
+  serializeAttachment(attachment: any): void;
+  deserializeAttachment(): any | null;
+  /**
+   * Returns the state of the WebSocket object's connection. It can have the values described below.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/readyState)
+   */
+  readyState: number;
+  /**
+   * Returns the URL that was used to establish the WebSocket connection.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/url)
+   */
+  url: string | null;
+  /**
+   * Returns the subprotocol selected by the server, if any. It can be used in conjunction with the array form of the constructor's second argument to perform subprotocol negotiation.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/protocol)
+   */
+  protocol: string | null;
+  /**
+   * Returns the extensions selected by the server, if any.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/extensions)
+   */
+  extensions: string | null;
 }
 declare const WebSocketPair: {
-    new (): {
-        0: WebSocket;
-        1: WebSocket;
-    };
+  new (): {
+    0: WebSocket;
+    1: WebSocket;
+  };
 };
 interface SqlStorage {
-    exec<T extends Record<string, SqlStorageValue>>(query: string, ...bindings: any[]): SqlStorageCursor<T>;
-    get databaseSize(): number;
-    Cursor: typeof SqlStorageCursor;
-    Statement: typeof SqlStorageStatement;
+  exec<T extends Record<string, SqlStorageValue>>(
+    query: string,
+    ...bindings: any[]
+  ): SqlStorageCursor<T>;
+  get databaseSize(): number;
+  Cursor: typeof SqlStorageCursor;
+  Statement: typeof SqlStorageStatement;
 }
-declare abstract class SqlStorageStatement {
-}
+declare abstract class SqlStorageStatement {}
 type SqlStorageValue = ArrayBuffer | string | number | null;
 declare abstract class SqlStorageCursor<T extends Record<string, SqlStorageValue>> {
-    next(): {
+  next():
+    | {
         done?: false;
         value: T;
-    } | {
+      }
+    | {
         done: true;
         value?: never;
-    };
-    toArray(): T[];
-    one(): T;
-    raw<U extends SqlStorageValue[]>(): IterableIterator<U>;
-    columnNames: string[];
-    get rowsRead(): number;
-    get rowsWritten(): number;
-    [Symbol.iterator](): IterableIterator<T>;
+      };
+  toArray(): T[];
+  one(): T;
+  raw<U extends SqlStorageValue[]>(): IterableIterator<U>;
+  columnNames: string[];
+  get rowsRead(): number;
+  get rowsWritten(): number;
+  [Symbol.iterator](): IterableIterator<T>;
 }
 interface Socket {
-    get readable(): ReadableStream;
-    get writable(): WritableStream;
-    get closed(): Promise<void>;
-    get opened(): Promise<SocketInfo>;
-    get upgraded(): boolean;
-    get secureTransport(): "on" | "off" | "starttls";
-    close(): Promise<void>;
-    startTls(options?: TlsOptions): Socket;
+  get readable(): ReadableStream;
+  get writable(): WritableStream;
+  get closed(): Promise<void>;
+  get opened(): Promise<SocketInfo>;
+  get upgraded(): boolean;
+  get secureTransport(): "on" | "off" | "starttls";
+  close(): Promise<void>;
+  startTls(options?: TlsOptions): Socket;
 }
 interface SocketOptions {
-    secureTransport?: string;
-    allowHalfOpen: boolean;
-    highWaterMark?: (number | bigint);
+  secureTransport?: string;
+  allowHalfOpen: boolean;
+  highWaterMark?: number | bigint;
 }
 interface SocketAddress {
-    hostname: string;
-    port: number;
+  hostname: string;
+  port: number;
 }
 interface TlsOptions {
-    expectedServerHostname?: string;
+  expectedServerHostname?: string;
 }
 interface SocketInfo {
-    remoteAddress?: string;
-    localAddress?: string;
+  remoteAddress?: string;
+  localAddress?: string;
 }
 /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource) */
 declare class EventSource extends EventTarget {
-    constructor(url: string, init?: EventSourceEventSourceInit);
-    /**
-     * Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/close)
-     */
-    close(): void;
-    /**
-     * Returns the URL providing the event stream.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/url)
-     */
-    get url(): string;
-    /**
-     * Returns true if the credentials mode for connection requests to the URL providing the event stream is set to "include", and false otherwise.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/withCredentials)
-     */
-    get withCredentials(): boolean;
-    /**
-     * Returns the state of this EventSource object's connection. It can have the values described below.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/readyState)
-     */
-    get readyState(): number;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
-    get onopen(): any | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
-    set onopen(value: any | null);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
-    get onmessage(): any | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
-    set onmessage(value: any | null);
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
-    get onerror(): any | null;
-    /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
-    set onerror(value: any | null);
-    static readonly CONNECTING: number;
-    static readonly OPEN: number;
-    static readonly CLOSED: number;
-    static from(stream: ReadableStream): EventSource;
+  constructor(url: string, init?: EventSourceEventSourceInit);
+  /**
+   * Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/close)
+   */
+  close(): void;
+  /**
+   * Returns the URL providing the event stream.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/url)
+   */
+  get url(): string;
+  /**
+   * Returns true if the credentials mode for connection requests to the URL providing the event stream is set to "include", and false otherwise.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/withCredentials)
+   */
+  get withCredentials(): boolean;
+  /**
+   * Returns the state of this EventSource object's connection. It can have the values described below.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/readyState)
+   */
+  get readyState(): number;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
+  get onopen(): any | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
+  set onopen(value: any | null);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
+  get onmessage(): any | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
+  set onmessage(value: any | null);
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
+  get onerror(): any | null;
+  /* [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
+  set onerror(value: any | null);
+  static readonly CONNECTING: number;
+  static readonly OPEN: number;
+  static readonly CLOSED: number;
+  static from(stream: ReadableStream): EventSource;
 }
 interface EventSourceEventSourceInit {
-    withCredentials?: boolean;
-    fetcher?: Fetcher;
+  withCredentials?: boolean;
+  fetcher?: Fetcher;
 }
 interface Container {
-    get running(): boolean;
-    start(options?: ContainerStartupOptions): void;
-    monitor(): Promise<void>;
-    destroy(error?: any): Promise<void>;
-    signal(signo: number): void;
-    getTcpPort(port: number): Fetcher;
+  get running(): boolean;
+  start(options?: ContainerStartupOptions): void;
+  monitor(): Promise<void>;
+  destroy(error?: any): Promise<void>;
+  signal(signo: number): void;
+  getTcpPort(port: number): Fetcher;
 }
 interface ContainerStartupOptions {
-    entrypoint?: string[];
-    enableInternet: boolean;
-    env?: Record<string, string>;
+  entrypoint?: string[];
+  enableInternet: boolean;
+  env?: Record<string, string>;
 }
 /**
  * This Channel Messaging API interface represents one of the two ports of a MessageChannel, allowing messages to be sent from one port and listening out for them arriving at the other.
@@ -2511,449 +2853,476 @@ interface ContainerStartupOptions {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort)
  */
 interface MessagePort extends EventTarget {
-    /**
-     * Posts a message through the channel. Objects listed in transfer are transferred, not just cloned, meaning that they are no longer usable on the sending side.
-     *
-     * Throws a "DataCloneError" DOMException if transfer contains duplicate objects or port, or if message could not be cloned.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
-     */
-    postMessage(data?: any, options?: (any[] | MessagePortPostMessageOptions)): void;
-    /**
-     * Disconnects the port, so that it is no longer active.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/close)
-     */
-    close(): void;
-    /**
-     * Begins dispatching messages received on the port.
-     *
-     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/start)
-     */
-    start(): void;
-    get onmessage(): any | null;
-    set onmessage(value: any | null);
+  /**
+   * Posts a message through the channel. Objects listed in transfer are transferred, not just cloned, meaning that they are no longer usable on the sending side.
+   *
+   * Throws a "DataCloneError" DOMException if transfer contains duplicate objects or port, or if message could not be cloned.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/postMessage)
+   */
+  postMessage(data?: any, options?: any[] | MessagePortPostMessageOptions): void;
+  /**
+   * Disconnects the port, so that it is no longer active.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/close)
+   */
+  close(): void;
+  /**
+   * Begins dispatching messages received on the port.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessagePort/start)
+   */
+  start(): void;
+  get onmessage(): any | null;
+  set onmessage(value: any | null);
 }
 interface MessagePortPostMessageOptions {
-    transfer?: any[];
+  transfer?: any[];
 }
-type LoopbackForExport<T extends (new (...args: any[]) => Rpc.EntrypointBranded) | ExportedHandler<any, any, any> | undefined = undefined> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded ? LoopbackServiceStub<InstanceType<T>> : T extends new (...args: any[]) => Rpc.DurableObjectBranded ? LoopbackDurableObjectClass<InstanceType<T>> : T extends ExportedHandler<any, any, any> ? LoopbackServiceStub<undefined> : undefined;
-type LoopbackServiceStub<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> = Fetcher<T> & (T extends CloudflareWorkersModule.WorkerEntrypoint<any, infer Props> ? (opts: {
-    props?: Props;
-}) => Fetcher<T> : (opts: {
-    props?: any;
-}) => Fetcher<T>);
-type LoopbackDurableObjectClass<T extends Rpc.DurableObjectBranded | undefined = undefined> = DurableObjectClass<T> & (T extends CloudflareWorkersModule.DurableObject<any, infer Props> ? (opts: {
-    props?: Props;
-}) => DurableObjectClass<T> : (opts: {
-    props?: any;
-}) => DurableObjectClass<T>);
+type LoopbackForExport<
+  T extends
+    | (new (...args: any[]) => Rpc.EntrypointBranded)
+    | ExportedHandler<any, any, any>
+    | undefined = undefined,
+> = T extends new (...args: any[]) => Rpc.WorkerEntrypointBranded
+  ? LoopbackServiceStub<InstanceType<T>>
+  : T extends new (...args: any[]) => Rpc.DurableObjectBranded
+    ? LoopbackDurableObjectClass<InstanceType<T>>
+    : T extends ExportedHandler<any, any, any>
+      ? LoopbackServiceStub<undefined>
+      : undefined;
+type LoopbackServiceStub<T extends Rpc.WorkerEntrypointBranded | undefined = undefined> =
+  Fetcher<T> &
+    (T extends CloudflareWorkersModule.WorkerEntrypoint<any, infer Props>
+      ? (opts: { props?: Props }) => Fetcher<T>
+      : (opts: { props?: any }) => Fetcher<T>);
+type LoopbackDurableObjectClass<T extends Rpc.DurableObjectBranded | undefined = undefined> =
+  DurableObjectClass<T> &
+    (T extends CloudflareWorkersModule.DurableObject<any, infer Props>
+      ? (opts: { props?: Props }) => DurableObjectClass<T>
+      : (opts: { props?: any }) => DurableObjectClass<T>);
 interface SyncKvStorage {
-    get<T = unknown>(key: string): T | undefined;
-    list<T = unknown>(options?: SyncKvListOptions): Iterable<[
-        string,
-        T
-    ]>;
-    put<T>(key: string, value: T): void;
-    delete(key: string): boolean;
+  get<T = unknown>(key: string): T | undefined;
+  list<T = unknown>(options?: SyncKvListOptions): Iterable<[string, T]>;
+  put<T>(key: string, value: T): void;
+  delete(key: string): boolean;
 }
 interface SyncKvListOptions {
-    start?: string;
-    startAfter?: string;
-    end?: string;
-    prefix?: string;
-    reverse?: boolean;
-    limit?: number;
+  start?: string;
+  startAfter?: string;
+  end?: string;
+  prefix?: string;
+  reverse?: boolean;
+  limit?: number;
 }
 interface WorkerStub {
-    getEntrypoint<T extends Rpc.WorkerEntrypointBranded | undefined>(name?: string, options?: WorkerStubEntrypointOptions): Fetcher<T>;
+  getEntrypoint<T extends Rpc.WorkerEntrypointBranded | undefined>(
+    name?: string,
+    options?: WorkerStubEntrypointOptions,
+  ): Fetcher<T>;
 }
 interface WorkerStubEntrypointOptions {
-    props?: any;
+  props?: any;
 }
 interface WorkerLoader {
-    get(name: string, getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>): WorkerStub;
+  get(
+    name: string,
+    getCode: () => WorkerLoaderWorkerCode | Promise<WorkerLoaderWorkerCode>,
+  ): WorkerStub;
 }
 interface WorkerLoaderModule {
-    js?: string;
-    cjs?: string;
-    text?: string;
-    data?: ArrayBuffer;
-    json?: any;
-    py?: string;
+  js?: string;
+  cjs?: string;
+  text?: string;
+  data?: ArrayBuffer;
+  json?: any;
+  py?: string;
 }
 interface WorkerLoaderWorkerCode {
-    compatibilityDate: string;
-    compatibilityFlags?: string[];
-    allowExperimental?: boolean;
-    mainModule: string;
-    modules: Record<string, WorkerLoaderModule | string>;
-    env?: any;
-    globalOutbound?: (Fetcher | null);
-    tails?: Fetcher[];
-    streamingTails?: Fetcher[];
+  compatibilityDate: string;
+  compatibilityFlags?: string[];
+  allowExperimental?: boolean;
+  mainModule: string;
+  modules: Record<string, WorkerLoaderModule | string>;
+  env?: any;
+  globalOutbound?: Fetcher | null;
+  tails?: Fetcher[];
+  streamingTails?: Fetcher[];
 }
 /**
-* The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
-* as well as timing of subrequests and other operations.
-*
-* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
-*/
+ * The Workers runtime supports a subset of the Performance API, used to measure timing and performance,
+ * as well as timing of subrequests and other operations.
+ *
+ * [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/)
+ */
 declare abstract class Performance {
-    /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
-    get timeOrigin(): number;
-    /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
-    now(): number;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancetimeorigin) */
+  get timeOrigin(): number;
+  /* [Cloudflare Docs Reference](https://developers.cloudflare.com/workers/runtime-apis/performance/#performancenow) */
+  now(): number;
 }
 type AiImageClassificationInput = {
-    image: number[];
+  image: number[];
 };
 type AiImageClassificationOutput = {
-    score?: number;
-    label?: string;
+  score?: number;
+  label?: string;
 }[];
 declare abstract class BaseAiImageClassification {
-    inputs: AiImageClassificationInput;
-    postProcessedOutputs: AiImageClassificationOutput;
+  inputs: AiImageClassificationInput;
+  postProcessedOutputs: AiImageClassificationOutput;
 }
 type AiImageToTextInput = {
-    image: number[];
-    prompt?: string;
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    seed?: number;
-    repetition_penalty?: number;
-    frequency_penalty?: number;
-    presence_penalty?: number;
-    raw?: boolean;
-    messages?: RoleScopedChatInput[];
+  image: number[];
+  prompt?: string;
+  max_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  seed?: number;
+  repetition_penalty?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  raw?: boolean;
+  messages?: RoleScopedChatInput[];
 };
 type AiImageToTextOutput = {
-    description: string;
+  description: string;
 };
 declare abstract class BaseAiImageToText {
-    inputs: AiImageToTextInput;
-    postProcessedOutputs: AiImageToTextOutput;
+  inputs: AiImageToTextInput;
+  postProcessedOutputs: AiImageToTextOutput;
 }
 type AiImageTextToTextInput = {
-    image: string;
-    prompt?: string;
-    max_tokens?: number;
-    temperature?: number;
-    ignore_eos?: boolean;
-    top_p?: number;
-    top_k?: number;
-    seed?: number;
-    repetition_penalty?: number;
-    frequency_penalty?: number;
-    presence_penalty?: number;
-    raw?: boolean;
-    messages?: RoleScopedChatInput[];
+  image: string;
+  prompt?: string;
+  max_tokens?: number;
+  temperature?: number;
+  ignore_eos?: boolean;
+  top_p?: number;
+  top_k?: number;
+  seed?: number;
+  repetition_penalty?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  raw?: boolean;
+  messages?: RoleScopedChatInput[];
 };
 type AiImageTextToTextOutput = {
-    description: string;
+  description: string;
 };
 declare abstract class BaseAiImageTextToText {
-    inputs: AiImageTextToTextInput;
-    postProcessedOutputs: AiImageTextToTextOutput;
+  inputs: AiImageTextToTextInput;
+  postProcessedOutputs: AiImageTextToTextOutput;
 }
 type AiMultimodalEmbeddingsInput = {
-    image: string;
-    text: string[];
+  image: string;
+  text: string[];
 };
 type AiIMultimodalEmbeddingsOutput = {
-    data: number[][];
-    shape: number[];
+  data: number[][];
+  shape: number[];
 };
 declare abstract class BaseAiMultimodalEmbeddings {
-    inputs: AiImageTextToTextInput;
-    postProcessedOutputs: AiImageTextToTextOutput;
+  inputs: AiImageTextToTextInput;
+  postProcessedOutputs: AiImageTextToTextOutput;
 }
 type AiObjectDetectionInput = {
-    image: number[];
+  image: number[];
 };
 type AiObjectDetectionOutput = {
-    score?: number;
-    label?: string;
+  score?: number;
+  label?: string;
 }[];
 declare abstract class BaseAiObjectDetection {
-    inputs: AiObjectDetectionInput;
-    postProcessedOutputs: AiObjectDetectionOutput;
+  inputs: AiObjectDetectionInput;
+  postProcessedOutputs: AiObjectDetectionOutput;
 }
 type AiSentenceSimilarityInput = {
-    source: string;
-    sentences: string[];
+  source: string;
+  sentences: string[];
 };
 type AiSentenceSimilarityOutput = number[];
 declare abstract class BaseAiSentenceSimilarity {
-    inputs: AiSentenceSimilarityInput;
-    postProcessedOutputs: AiSentenceSimilarityOutput;
+  inputs: AiSentenceSimilarityInput;
+  postProcessedOutputs: AiSentenceSimilarityOutput;
 }
 type AiAutomaticSpeechRecognitionInput = {
-    audio: number[];
+  audio: number[];
 };
 type AiAutomaticSpeechRecognitionOutput = {
-    text?: string;
-    words?: {
-        word: string;
-        start: number;
-        end: number;
-    }[];
-    vtt?: string;
+  text?: string;
+  words?: {
+    word: string;
+    start: number;
+    end: number;
+  }[];
+  vtt?: string;
 };
 declare abstract class BaseAiAutomaticSpeechRecognition {
-    inputs: AiAutomaticSpeechRecognitionInput;
-    postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
+  inputs: AiAutomaticSpeechRecognitionInput;
+  postProcessedOutputs: AiAutomaticSpeechRecognitionOutput;
 }
 type AiSummarizationInput = {
-    input_text: string;
-    max_length?: number;
+  input_text: string;
+  max_length?: number;
 };
 type AiSummarizationOutput = {
-    summary: string;
+  summary: string;
 };
 declare abstract class BaseAiSummarization {
-    inputs: AiSummarizationInput;
-    postProcessedOutputs: AiSummarizationOutput;
+  inputs: AiSummarizationInput;
+  postProcessedOutputs: AiSummarizationOutput;
 }
 type AiTextClassificationInput = {
-    text: string;
+  text: string;
 };
 type AiTextClassificationOutput = {
-    score?: number;
-    label?: string;
+  score?: number;
+  label?: string;
 }[];
 declare abstract class BaseAiTextClassification {
-    inputs: AiTextClassificationInput;
-    postProcessedOutputs: AiTextClassificationOutput;
+  inputs: AiTextClassificationInput;
+  postProcessedOutputs: AiTextClassificationOutput;
 }
 type AiTextEmbeddingsInput = {
-    text: string | string[];
+  text: string | string[];
 };
 type AiTextEmbeddingsOutput = {
-    shape: number[];
-    data: number[][];
+  shape: number[];
+  data: number[][];
 };
 declare abstract class BaseAiTextEmbeddings {
-    inputs: AiTextEmbeddingsInput;
-    postProcessedOutputs: AiTextEmbeddingsOutput;
+  inputs: AiTextEmbeddingsInput;
+  postProcessedOutputs: AiTextEmbeddingsOutput;
 }
 type RoleScopedChatInput = {
-    role: "user" | "assistant" | "system" | "tool" | (string & NonNullable<unknown>);
-    content: string;
-    name?: string;
+  role: "user" | "assistant" | "system" | "tool" | (string & NonNullable<unknown>);
+  content: string;
+  name?: string;
 };
 type AiTextGenerationToolLegacyInput = {
+  name: string;
+  description: string;
+  parameters?: {
+    type: "object" | (string & NonNullable<unknown>);
+    properties: {
+      [key: string]: {
+        type: string;
+        description?: string;
+      };
+    };
+    required: string[];
+  };
+};
+type AiTextGenerationToolInput = {
+  type: "function" | (string & NonNullable<unknown>);
+  function: {
     name: string;
     description: string;
     parameters?: {
-        type: "object" | (string & NonNullable<unknown>);
-        properties: {
-            [key: string]: {
-                type: string;
-                description?: string;
-            };
+      type: "object" | (string & NonNullable<unknown>);
+      properties: {
+        [key: string]: {
+          type: string;
+          description?: string;
         };
-        required: string[];
+      };
+      required: string[];
     };
-};
-type AiTextGenerationToolInput = {
-    type: "function" | (string & NonNullable<unknown>);
-    function: {
-        name: string;
-        description: string;
-        parameters?: {
-            type: "object" | (string & NonNullable<unknown>);
-            properties: {
-                [key: string]: {
-                    type: string;
-                    description?: string;
-                };
-            };
-            required: string[];
-        };
-    };
+  };
 };
 type AiTextGenerationFunctionsInput = {
-    name: string;
-    code: string;
+  name: string;
+  code: string;
 };
 type AiTextGenerationResponseFormat = {
-    type: string;
-    json_schema?: any;
+  type: string;
+  json_schema?: any;
 };
 type AiTextGenerationInput = {
-    prompt?: string;
-    raw?: boolean;
-    stream?: boolean;
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    seed?: number;
-    repetition_penalty?: number;
-    frequency_penalty?: number;
-    presence_penalty?: number;
-    messages?: RoleScopedChatInput[];
-    response_format?: AiTextGenerationResponseFormat;
-    tools?: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[] | (object & NonNullable<unknown>);
-    functions?: AiTextGenerationFunctionsInput[];
+  prompt?: string;
+  raw?: boolean;
+  stream?: boolean;
+  max_tokens?: number;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  seed?: number;
+  repetition_penalty?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  messages?: RoleScopedChatInput[];
+  response_format?: AiTextGenerationResponseFormat;
+  tools?:
+    | AiTextGenerationToolInput[]
+    | AiTextGenerationToolLegacyInput[]
+    | (object & NonNullable<unknown>);
+  functions?: AiTextGenerationFunctionsInput[];
 };
 type AiTextGenerationToolLegacyOutput = {
-    name: string;
-    arguments: unknown;
+  name: string;
+  arguments: unknown;
 };
 type AiTextGenerationToolOutput = {
-    id: string;
-    type: "function";
-    function: {
-        name: string;
-        arguments: string;
-    };
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
 };
 type UsageTags = {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
 };
 type AiTextGenerationOutput = {
-    response?: string;
-    tool_calls?: AiTextGenerationToolLegacyOutput[] & AiTextGenerationToolOutput[];
-    usage?: UsageTags;
+  response?: string;
+  tool_calls?: AiTextGenerationToolLegacyOutput[] & AiTextGenerationToolOutput[];
+  usage?: UsageTags;
 };
 declare abstract class BaseAiTextGeneration {
-    inputs: AiTextGenerationInput;
-    postProcessedOutputs: AiTextGenerationOutput;
+  inputs: AiTextGenerationInput;
+  postProcessedOutputs: AiTextGenerationOutput;
 }
 type AiTextToSpeechInput = {
-    prompt: string;
-    lang?: string;
+  prompt: string;
+  lang?: string;
 };
-type AiTextToSpeechOutput = Uint8Array | {
-    audio: string;
-};
+type AiTextToSpeechOutput =
+  | Uint8Array
+  | {
+      audio: string;
+    };
 declare abstract class BaseAiTextToSpeech {
-    inputs: AiTextToSpeechInput;
-    postProcessedOutputs: AiTextToSpeechOutput;
+  inputs: AiTextToSpeechInput;
+  postProcessedOutputs: AiTextToSpeechOutput;
 }
 type AiTextToImageInput = {
-    prompt: string;
-    negative_prompt?: string;
-    height?: number;
-    width?: number;
-    image?: number[];
-    image_b64?: string;
-    mask?: number[];
-    num_steps?: number;
-    strength?: number;
-    guidance?: number;
-    seed?: number;
+  prompt: string;
+  negative_prompt?: string;
+  height?: number;
+  width?: number;
+  image?: number[];
+  image_b64?: string;
+  mask?: number[];
+  num_steps?: number;
+  strength?: number;
+  guidance?: number;
+  seed?: number;
 };
 type AiTextToImageOutput = ReadableStream<Uint8Array>;
 declare abstract class BaseAiTextToImage {
-    inputs: AiTextToImageInput;
-    postProcessedOutputs: AiTextToImageOutput;
+  inputs: AiTextToImageInput;
+  postProcessedOutputs: AiTextToImageOutput;
 }
 type AiTranslationInput = {
-    text: string;
-    target_lang: string;
-    source_lang?: string;
+  text: string;
+  target_lang: string;
+  source_lang?: string;
 };
 type AiTranslationOutput = {
-    translated_text?: string;
+  translated_text?: string;
 };
 declare abstract class BaseAiTranslation {
-    inputs: AiTranslationInput;
-    postProcessedOutputs: AiTranslationOutput;
+  inputs: AiTranslationInput;
+  postProcessedOutputs: AiTranslationOutput;
 }
-type Ai_Cf_Baai_Bge_Base_En_V1_5_Input = {
-    text: string | string[];
-    /**
-     * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
-     */
-    pooling?: "mean" | "cls";
-} | {
-    /**
-     * Batch of the embeddings requests to run using async-queue
-     */
-    requests: {
+type Ai_Cf_Baai_Bge_Base_En_V1_5_Input =
+  | {
+      text: string | string[];
+      /**
+       * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
+       */
+      pooling?: "mean" | "cls";
+    }
+  | {
+      /**
+       * Batch of the embeddings requests to run using async-queue
+       */
+      requests: {
         text: string | string[];
         /**
          * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
          */
         pooling?: "mean" | "cls";
-    }[];
-};
-type Ai_Cf_Baai_Bge_Base_En_V1_5_Output = {
-    shape?: number[];
-    /**
-     * Embeddings of the requested text values
-     */
-    data?: number[][];
-    /**
-     * The pooling method used in the embedding process.
-     */
-    pooling?: "mean" | "cls";
-} | AsyncResponse;
+      }[];
+    };
+type Ai_Cf_Baai_Bge_Base_En_V1_5_Output =
+  | {
+      shape?: number[];
+      /**
+       * Embeddings of the requested text values
+       */
+      data?: number[][];
+      /**
+       * The pooling method used in the embedding process.
+       */
+      pooling?: "mean" | "cls";
+    }
+  | AsyncResponse;
 interface AsyncResponse {
-    /**
-     * The async request id that can be used to obtain the results.
-     */
-    request_id?: string;
+  /**
+   * The async request id that can be used to obtain the results.
+   */
+  request_id?: string;
 }
 declare abstract class Base_Ai_Cf_Baai_Bge_Base_En_V1_5 {
-    inputs: Ai_Cf_Baai_Bge_Base_En_V1_5_Input;
-    postProcessedOutputs: Ai_Cf_Baai_Bge_Base_En_V1_5_Output;
+  inputs: Ai_Cf_Baai_Bge_Base_En_V1_5_Input;
+  postProcessedOutputs: Ai_Cf_Baai_Bge_Base_En_V1_5_Output;
 }
-type Ai_Cf_Openai_Whisper_Input = string | {
-    /**
-     * An array of integers that represent the audio data constrained to 8-bit unsigned integer values
-     */
-    audio: number[];
-};
+type Ai_Cf_Openai_Whisper_Input =
+  | string
+  | {
+      /**
+       * An array of integers that represent the audio data constrained to 8-bit unsigned integer values
+       */
+      audio: number[];
+    };
 interface Ai_Cf_Openai_Whisper_Output {
+  /**
+   * The transcription
+   */
+  text: string;
+  word_count?: number;
+  words?: {
+    word?: string;
     /**
-     * The transcription
+     * The second this word begins in the recording
      */
-    text: string;
-    word_count?: number;
-    words?: {
-        word?: string;
-        /**
-         * The second this word begins in the recording
-         */
-        start?: number;
-        /**
-         * The ending second when the word completes
-         */
-        end?: number;
-    }[];
-    vtt?: string;
+    start?: number;
+    /**
+     * The ending second when the word completes
+     */
+    end?: number;
+  }[];
+  vtt?: string;
 }
 declare abstract class Base_Ai_Cf_Openai_Whisper {
-    inputs: Ai_Cf_Openai_Whisper_Input;
-    postProcessedOutputs: Ai_Cf_Openai_Whisper_Output;
+  inputs: Ai_Cf_Openai_Whisper_Input;
+  postProcessedOutputs: Ai_Cf_Openai_Whisper_Output;
 }
-type Ai_Cf_Meta_M2M100_1_2B_Input = {
-    /**
-     * The text to be translated
-     */
-    text: string;
-    /**
-     * The language code of the source text (e.g., 'en' for English). Defaults to 'en' if not specified
-     */
-    source_lang?: string;
-    /**
-     * The language code to translate the text into (e.g., 'es' for Spanish)
-     */
-    target_lang: string;
-} | {
-    /**
-     * Batch of the embeddings requests to run using async-queue
-     */
-    requests: {
+type Ai_Cf_Meta_M2M100_1_2B_Input =
+  | {
+      /**
+       * The text to be translated
+       */
+      text: string;
+      /**
+       * The language code of the source text (e.g., 'en' for English). Defaults to 'en' if not specified
+       */
+      source_lang?: string;
+      /**
+       * The language code to translate the text into (e.g., 'es' for Spanish)
+       */
+      target_lang: string;
+    }
+  | {
+      /**
+       * Batch of the embeddings requests to run using async-queue
+       */
+      requests: {
         /**
          * The text to be translated
          */
@@ -2966,479 +3335,504 @@ type Ai_Cf_Meta_M2M100_1_2B_Input = {
          * The language code to translate the text into (e.g., 'es' for Spanish)
          */
         target_lang: string;
-    }[];
-};
-type Ai_Cf_Meta_M2M100_1_2B_Output = {
-    /**
-     * The translated text in the target language
-     */
-    translated_text?: string;
-} | AsyncResponse;
+      }[];
+    };
+type Ai_Cf_Meta_M2M100_1_2B_Output =
+  | {
+      /**
+       * The translated text in the target language
+       */
+      translated_text?: string;
+    }
+  | AsyncResponse;
 declare abstract class Base_Ai_Cf_Meta_M2M100_1_2B {
-    inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
-    postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
+  inputs: Ai_Cf_Meta_M2M100_1_2B_Input;
+  postProcessedOutputs: Ai_Cf_Meta_M2M100_1_2B_Output;
 }
-type Ai_Cf_Baai_Bge_Small_En_V1_5_Input = {
-    text: string | string[];
-    /**
-     * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
-     */
-    pooling?: "mean" | "cls";
-} | {
-    /**
-     * Batch of the embeddings requests to run using async-queue
-     */
-    requests: {
+type Ai_Cf_Baai_Bge_Small_En_V1_5_Input =
+  | {
+      text: string | string[];
+      /**
+       * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
+       */
+      pooling?: "mean" | "cls";
+    }
+  | {
+      /**
+       * Batch of the embeddings requests to run using async-queue
+       */
+      requests: {
         text: string | string[];
         /**
          * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
          */
         pooling?: "mean" | "cls";
-    }[];
-};
-type Ai_Cf_Baai_Bge_Small_En_V1_5_Output = {
-    shape?: number[];
-    /**
-     * Embeddings of the requested text values
-     */
-    data?: number[][];
-    /**
-     * The pooling method used in the embedding process.
-     */
-    pooling?: "mean" | "cls";
-} | AsyncResponse;
+      }[];
+    };
+type Ai_Cf_Baai_Bge_Small_En_V1_5_Output =
+  | {
+      shape?: number[];
+      /**
+       * Embeddings of the requested text values
+       */
+      data?: number[][];
+      /**
+       * The pooling method used in the embedding process.
+       */
+      pooling?: "mean" | "cls";
+    }
+  | AsyncResponse;
 declare abstract class Base_Ai_Cf_Baai_Bge_Small_En_V1_5 {
-    inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
-    postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
+  inputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Input;
+  postProcessedOutputs: Ai_Cf_Baai_Bge_Small_En_V1_5_Output;
 }
-type Ai_Cf_Baai_Bge_Large_En_V1_5_Input = {
-    text: string | string[];
-    /**
-     * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
-     */
-    pooling?: "mean" | "cls";
-} | {
-    /**
-     * Batch of the embeddings requests to run using async-queue
-     */
-    requests: {
+type Ai_Cf_Baai_Bge_Large_En_V1_5_Input =
+  | {
+      text: string | string[];
+      /**
+       * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
+       */
+      pooling?: "mean" | "cls";
+    }
+  | {
+      /**
+       * Batch of the embeddings requests to run using async-queue
+       */
+      requests: {
         text: string | string[];
         /**
          * The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy.
          */
         pooling?: "mean" | "cls";
-    }[];
-};
-type Ai_Cf_Baai_Bge_Large_En_V1_5_Output = {
-    shape?: number[];
-    /**
-     * Embeddings of the requested text values
-     */
-    data?: number[][];
-    /**
-     * The pooling method used in the embedding process.
-     */
-    pooling?: "mean" | "cls";
-} | AsyncResponse;
+      }[];
+    };
+type Ai_Cf_Baai_Bge_Large_En_V1_5_Output =
+  | {
+      shape?: number[];
+      /**
+       * Embeddings of the requested text values
+       */
+      data?: number[][];
+      /**
+       * The pooling method used in the embedding process.
+       */
+      pooling?: "mean" | "cls";
+    }
+  | AsyncResponse;
 declare abstract class Base_Ai_Cf_Baai_Bge_Large_En_V1_5 {
-    inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
-    postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
+  inputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Input;
+  postProcessedOutputs: Ai_Cf_Baai_Bge_Large_En_V1_5_Output;
 }
-type Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Input = string | {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt?: string;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
-    image: number[] | (string & NonNullable<unknown>);
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-};
+type Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Input =
+  | string
+  | {
+      /**
+       * The input text prompt for the model to generate a response.
+       */
+      prompt?: string;
+      /**
+       * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+       */
+      raw?: boolean;
+      /**
+       * Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+       */
+      top_p?: number;
+      /**
+       * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+       */
+      top_k?: number;
+      /**
+       * Random seed for reproducibility of the generation.
+       */
+      seed?: number;
+      /**
+       * Penalty for repeated tokens; higher values discourage repetition.
+       */
+      repetition_penalty?: number;
+      /**
+       * Decreases the likelihood of the model repeating the same lines verbatim.
+       */
+      frequency_penalty?: number;
+      /**
+       * Increases the likelihood of the model introducing new topics.
+       */
+      presence_penalty?: number;
+      image: number[] | (string & NonNullable<unknown>);
+      /**
+       * The maximum number of tokens to generate in the response.
+       */
+      max_tokens?: number;
+    };
 interface Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Output {
-    description?: string;
+  description?: string;
 }
 declare abstract class Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M {
-    inputs: Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Input;
-    postProcessedOutputs: Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Output;
+  inputs: Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Input;
+  postProcessedOutputs: Ai_Cf_Unum_Uform_Gen2_Qwen_500M_Output;
 }
-type Ai_Cf_Openai_Whisper_Tiny_En_Input = string | {
-    /**
-     * An array of integers that represent the audio data constrained to 8-bit unsigned integer values
-     */
-    audio: number[];
-};
+type Ai_Cf_Openai_Whisper_Tiny_En_Input =
+  | string
+  | {
+      /**
+       * An array of integers that represent the audio data constrained to 8-bit unsigned integer values
+       */
+      audio: number[];
+    };
 interface Ai_Cf_Openai_Whisper_Tiny_En_Output {
+  /**
+   * The transcription
+   */
+  text: string;
+  word_count?: number;
+  words?: {
+    word?: string;
     /**
-     * The transcription
+     * The second this word begins in the recording
      */
-    text: string;
-    word_count?: number;
-    words?: {
-        word?: string;
-        /**
-         * The second this word begins in the recording
-         */
-        start?: number;
-        /**
-         * The ending second when the word completes
-         */
-        end?: number;
-    }[];
-    vtt?: string;
+    start?: number;
+    /**
+     * The ending second when the word completes
+     */
+    end?: number;
+  }[];
+  vtt?: string;
 }
 declare abstract class Base_Ai_Cf_Openai_Whisper_Tiny_En {
-    inputs: Ai_Cf_Openai_Whisper_Tiny_En_Input;
-    postProcessedOutputs: Ai_Cf_Openai_Whisper_Tiny_En_Output;
+  inputs: Ai_Cf_Openai_Whisper_Tiny_En_Input;
+  postProcessedOutputs: Ai_Cf_Openai_Whisper_Tiny_En_Output;
 }
 interface Ai_Cf_Openai_Whisper_Large_V3_Turbo_Input {
-    /**
-     * Base64 encoded value of the audio data.
-     */
-    audio: string;
-    /**
-     * Supported tasks are 'translate' or 'transcribe'.
-     */
-    task?: string;
+  /**
+   * Base64 encoded value of the audio data.
+   */
+  audio: string;
+  /**
+   * Supported tasks are 'translate' or 'transcribe'.
+   */
+  task?: string;
+  /**
+   * The language of the audio being transcribed or translated.
+   */
+  language?: string;
+  /**
+   * Preprocess the audio with a voice activity detection model.
+   */
+  vad_filter?: boolean;
+  /**
+   * A text prompt to help provide context to the model on the contents of the audio.
+   */
+  initial_prompt?: string;
+  /**
+   * The prefix it appended the the beginning of the output of the transcription and can guide the transcription result.
+   */
+  prefix?: string;
+}
+interface Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output {
+  transcription_info?: {
     /**
      * The language of the audio being transcribed or translated.
      */
     language?: string;
     /**
-     * Preprocess the audio with a voice activity detection model.
+     * The confidence level or probability of the detected language being accurate, represented as a decimal between 0 and 1.
      */
-    vad_filter?: boolean;
+    language_probability?: number;
     /**
-     * A text prompt to help provide context to the model on the contents of the audio.
+     * The total duration of the original audio file, in seconds.
      */
-    initial_prompt?: string;
+    duration?: number;
     /**
-     * The prefix it appended the the beginning of the output of the transcription and can guide the transcription result.
+     * The duration of the audio after applying Voice Activity Detection (VAD) to remove silent or irrelevant sections, in seconds.
      */
-    prefix?: string;
-}
-interface Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output {
-    transcription_info?: {
-        /**
-         * The language of the audio being transcribed or translated.
-         */
-        language?: string;
-        /**
-         * The confidence level or probability of the detected language being accurate, represented as a decimal between 0 and 1.
-         */
-        language_probability?: number;
-        /**
-         * The total duration of the original audio file, in seconds.
-         */
-        duration?: number;
-        /**
-         * The duration of the audio after applying Voice Activity Detection (VAD) to remove silent or irrelevant sections, in seconds.
-         */
-        duration_after_vad?: number;
-    };
+    duration_after_vad?: number;
+  };
+  /**
+   * The complete transcription of the audio.
+   */
+  text: string;
+  /**
+   * The total number of words in the transcription.
+   */
+  word_count?: number;
+  segments?: {
     /**
-     * The complete transcription of the audio.
+     * The starting time of the segment within the audio, in seconds.
      */
-    text: string;
+    start?: number;
     /**
-     * The total number of words in the transcription.
+     * The ending time of the segment within the audio, in seconds.
      */
-    word_count?: number;
-    segments?: {
-        /**
-         * The starting time of the segment within the audio, in seconds.
-         */
-        start?: number;
-        /**
-         * The ending time of the segment within the audio, in seconds.
-         */
-        end?: number;
-        /**
-         * The transcription of the segment.
-         */
-        text?: string;
-        /**
-         * The temperature used in the decoding process, controlling randomness in predictions. Lower values result in more deterministic outputs.
-         */
-        temperature?: number;
-        /**
-         * The average log probability of the predictions for the words in this segment, indicating overall confidence.
-         */
-        avg_logprob?: number;
-        /**
-         * The compression ratio of the input to the output, measuring how much the text was compressed during the transcription process.
-         */
-        compression_ratio?: number;
-        /**
-         * The probability that the segment contains no speech, represented as a decimal between 0 and 1.
-         */
-        no_speech_prob?: number;
-        words?: {
-            /**
-             * The individual word transcribed from the audio.
-             */
-            word?: string;
-            /**
-             * The starting time of the word within the audio, in seconds.
-             */
-            start?: number;
-            /**
-             * The ending time of the word within the audio, in seconds.
-             */
-            end?: number;
-        }[];
+    end?: number;
+    /**
+     * The transcription of the segment.
+     */
+    text?: string;
+    /**
+     * The temperature used in the decoding process, controlling randomness in predictions. Lower values result in more deterministic outputs.
+     */
+    temperature?: number;
+    /**
+     * The average log probability of the predictions for the words in this segment, indicating overall confidence.
+     */
+    avg_logprob?: number;
+    /**
+     * The compression ratio of the input to the output, measuring how much the text was compressed during the transcription process.
+     */
+    compression_ratio?: number;
+    /**
+     * The probability that the segment contains no speech, represented as a decimal between 0 and 1.
+     */
+    no_speech_prob?: number;
+    words?: {
+      /**
+       * The individual word transcribed from the audio.
+       */
+      word?: string;
+      /**
+       * The starting time of the word within the audio, in seconds.
+       */
+      start?: number;
+      /**
+       * The ending time of the word within the audio, in seconds.
+       */
+      end?: number;
     }[];
-    /**
-     * The transcription in WebVTT format, which includes timing and text information for use in subtitles.
-     */
-    vtt?: string;
+  }[];
+  /**
+   * The transcription in WebVTT format, which includes timing and text information for use in subtitles.
+   */
+  vtt?: string;
 }
 declare abstract class Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo {
-    inputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Input;
-    postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
+  inputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Input;
+  postProcessedOutputs: Ai_Cf_Openai_Whisper_Large_V3_Turbo_Output;
 }
-type Ai_Cf_Baai_Bge_M3_Input = BGEM3InputQueryAndContexts | BGEM3InputEmbedding | {
-    /**
-     * Batch of the embeddings requests to run using async-queue
-     */
-    requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
-};
+type Ai_Cf_Baai_Bge_M3_Input =
+  | BGEM3InputQueryAndContexts
+  | BGEM3InputEmbedding
+  | {
+      /**
+       * Batch of the embeddings requests to run using async-queue
+       */
+      requests: (BGEM3InputQueryAndContexts1 | BGEM3InputEmbedding1)[];
+    };
 interface BGEM3InputQueryAndContexts {
+  /**
+   * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
+   */
+  query?: string;
+  /**
+   * List of provided contexts. Note that the index in this array is important, as the response will refer to it.
+   */
+  contexts: {
     /**
-     * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
+     * One of the provided context content
      */
-    query?: string;
-    /**
-     * List of provided contexts. Note that the index in this array is important, as the response will refer to it.
-     */
-    contexts: {
-        /**
-         * One of the provided context content
-         */
-        text?: string;
-    }[];
-    /**
-     * When provided with too long context should the model error out or truncate the context to fit?
-     */
-    truncate_inputs?: boolean;
+    text?: string;
+  }[];
+  /**
+   * When provided with too long context should the model error out or truncate the context to fit?
+   */
+  truncate_inputs?: boolean;
 }
 interface BGEM3InputEmbedding {
-    text: string | string[];
-    /**
-     * When provided with too long context should the model error out or truncate the context to fit?
-     */
-    truncate_inputs?: boolean;
+  text: string | string[];
+  /**
+   * When provided with too long context should the model error out or truncate the context to fit?
+   */
+  truncate_inputs?: boolean;
 }
 interface BGEM3InputQueryAndContexts1 {
+  /**
+   * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
+   */
+  query?: string;
+  /**
+   * List of provided contexts. Note that the index in this array is important, as the response will refer to it.
+   */
+  contexts: {
     /**
-     * A query you wish to perform against the provided contexts. If no query is provided the model with respond with embeddings for contexts
+     * One of the provided context content
      */
-    query?: string;
-    /**
-     * List of provided contexts. Note that the index in this array is important, as the response will refer to it.
-     */
-    contexts: {
-        /**
-         * One of the provided context content
-         */
-        text?: string;
-    }[];
-    /**
-     * When provided with too long context should the model error out or truncate the context to fit?
-     */
-    truncate_inputs?: boolean;
+    text?: string;
+  }[];
+  /**
+   * When provided with too long context should the model error out or truncate the context to fit?
+   */
+  truncate_inputs?: boolean;
 }
 interface BGEM3InputEmbedding1 {
-    text: string | string[];
-    /**
-     * When provided with too long context should the model error out or truncate the context to fit?
-     */
-    truncate_inputs?: boolean;
+  text: string | string[];
+  /**
+   * When provided with too long context should the model error out or truncate the context to fit?
+   */
+  truncate_inputs?: boolean;
 }
-type Ai_Cf_Baai_Bge_M3_Output = BGEM3OuputQuery | BGEM3OutputEmbeddingForContexts | BGEM3OuputEmbedding | AsyncResponse;
+type Ai_Cf_Baai_Bge_M3_Output =
+  | BGEM3OuputQuery
+  | BGEM3OutputEmbeddingForContexts
+  | BGEM3OuputEmbedding
+  | AsyncResponse;
 interface BGEM3OuputQuery {
-    response?: {
-        /**
-         * Index of the context in the request
-         */
-        id?: number;
-        /**
-         * Score of the context under the index.
-         */
-        score?: number;
-    }[];
+  response?: {
+    /**
+     * Index of the context in the request
+     */
+    id?: number;
+    /**
+     * Score of the context under the index.
+     */
+    score?: number;
+  }[];
 }
 interface BGEM3OutputEmbeddingForContexts {
-    response?: number[][];
-    shape?: number[];
-    /**
-     * The pooling method used in the embedding process.
-     */
-    pooling?: "mean" | "cls";
+  response?: number[][];
+  shape?: number[];
+  /**
+   * The pooling method used in the embedding process.
+   */
+  pooling?: "mean" | "cls";
 }
 interface BGEM3OuputEmbedding {
-    shape?: number[];
-    /**
-     * Embeddings of the requested text values
-     */
-    data?: number[][];
-    /**
-     * The pooling method used in the embedding process.
-     */
-    pooling?: "mean" | "cls";
+  shape?: number[];
+  /**
+   * Embeddings of the requested text values
+   */
+  data?: number[][];
+  /**
+   * The pooling method used in the embedding process.
+   */
+  pooling?: "mean" | "cls";
 }
 declare abstract class Base_Ai_Cf_Baai_Bge_M3 {
-    inputs: Ai_Cf_Baai_Bge_M3_Input;
-    postProcessedOutputs: Ai_Cf_Baai_Bge_M3_Output;
+  inputs: Ai_Cf_Baai_Bge_M3_Input;
+  postProcessedOutputs: Ai_Cf_Baai_Bge_M3_Output;
 }
 interface Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input {
-    /**
-     * A text description of the image you want to generate.
-     */
-    prompt: string;
-    /**
-     * The number of diffusion steps; higher values can improve quality but take longer.
-     */
-    steps?: number;
+  /**
+   * A text description of the image you want to generate.
+   */
+  prompt: string;
+  /**
+   * The number of diffusion steps; higher values can improve quality but take longer.
+   */
+  steps?: number;
 }
 interface Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output {
-    /**
-     * The generated image in Base64 format.
-     */
-    image?: string;
+  /**
+   * The generated image in Base64 format.
+   */
+  image?: string;
 }
 declare abstract class Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell {
-    inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
-    postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
+  inputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Input;
+  postProcessedOutputs: Ai_Cf_Black_Forest_Labs_Flux_1_Schnell_Output;
 }
 type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input = Prompt | Messages;
 interface Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    image?: number[] | (string & NonNullable<unknown>);
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
-    /**
-     * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
-     */
-    lora?: string;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  image?: number[] | (string & NonNullable<unknown>);
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
 }
 interface Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role?: string;
-        /**
-         * The tool call id. Must be supplied for tool calls for Mistral-3. If you don't know what to put here you can fall back to 000000001
-         */
-        tool_call_id?: string;
-        content?: string | {
+    role?: string;
+    /**
+     * The tool call id. Must be supplied for tool calls for Mistral-3. If you don't know what to put here you can fall back to 000000001
+     */
+    tool_call_id?: string;
+    content?:
+      | string
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
-        }[] | {
+            url?: string;
+          };
+        }[]
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
+            url?: string;
+          };
         };
-    }[];
-    image?: number[] | (string & NonNullable<unknown>);
-    functions?: {
-        name: string;
-        code: string;
-    }[];
-    /**
-     * A list of tools available for the assistant to use.
-     */
-    tools?: ({
+  }[];
+  image?: number[] | (string & NonNullable<unknown>);
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -3451,6 +3845,52 @@ interface Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -3463,203 +3903,163 @@ interface Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    /**
-     * If true, the response will be streamed back incrementally.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  /**
+   * If true, the response will be streamed back incrementally.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Controls the creativity of the AI's responses by adjusting how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 type Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output = {
+  /**
+   * The generated text response from the model
+   */
+  response?: string;
+  /**
+   * An array of tool calls requests made during the response generation
+   */
+  tool_calls?: {
     /**
-     * The generated text response from the model
+     * The arguments passed to be passed to the tool call request
      */
-    response?: string;
+    arguments?: object;
     /**
-     * An array of tool calls requests made during the response generation
+     * The name of the tool to be called
      */
-    tool_calls?: {
-        /**
-         * The arguments passed to be passed to the tool call request
-         */
-        arguments?: object;
-        /**
-         * The name of the tool to be called
-         */
-        name?: string;
-    }[];
+    name?: string;
+  }[];
 };
 declare abstract class Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct {
-    inputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input;
-    postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
+  inputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Input;
+  postProcessedOutputs: Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Output;
 }
-type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input = Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages | AsyncBatch;
+type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input =
+  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt
+  | Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages
+  | AsyncBatch;
 interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
-     */
-    lora?: string;
-    response_format?: JSONMode;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: JSONMode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface JSONMode {
-    type?: "json_object" | "json_schema";
-    json_schema?: unknown;
+  type?: "json_object" | "json_schema";
+  json_schema?: unknown;
 }
 interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role: string;
-        /**
-         * The content of the message as a string.
-         */
-        content: string;
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
+    role: string;
     /**
-     * A list of tools available for the assistant to use.
+     * The content of the message as a string.
      */
-    tools?: ({
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -3672,6 +4072,52 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -3684,70 +4130,73 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    response_format?: JSONMode;
+      }
+  )[];
+  response_format?: JSONMode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
+}
+interface AsyncBatch {
+  requests?: {
     /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+     * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
      */
-    raw?: boolean;
+    external_reference?: string;
+    /**
+     * Prompt for the text generation model
+     */
+    prompt?: string;
     /**
      * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
      */
@@ -3765,10 +4214,6 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
      */
     top_p?: number;
     /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
      * Random seed for reproducibility of the generation.
      */
     seed?: number;
@@ -3784,61 +4229,19 @@ interface Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages {
      * Increases the likelihood of the model introducing new topics.
      */
     presence_penalty?: number;
+    response_format?: JSONMode;
+  }[];
 }
-interface AsyncBatch {
-    requests?: {
-        /**
-         * User-supplied reference. This field will be present in the response as well it can be used to reference the request and response. It's NOT validated to be unique.
-         */
-        external_reference?: string;
-        /**
-         * Prompt for the text generation model
-         */
-        prompt?: string;
-        /**
-         * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-         */
-        stream?: boolean;
-        /**
-         * The maximum number of tokens to generate in the response.
-         */
-        max_tokens?: number;
-        /**
-         * Controls the randomness of the output; higher values produce more random results.
-         */
-        temperature?: number;
-        /**
-         * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-         */
-        top_p?: number;
-        /**
-         * Random seed for reproducibility of the generation.
-         */
-        seed?: number;
-        /**
-         * Penalty for repeated tokens; higher values discourage repetition.
-         */
-        repetition_penalty?: number;
-        /**
-         * Decreases the likelihood of the model repeating the same lines verbatim.
-         */
-        frequency_penalty?: number;
-        /**
-         * Increases the likelihood of the model introducing new topics.
-         */
-        presence_penalty?: number;
-        response_format?: JSONMode;
-    }[];
-}
-type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output = {
-    /**
-     * The generated text response from the model
-     */
-    response: string;
-    /**
-     * Usage statistics for the inference request
-     */
-    usage?: {
+type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output =
+  | {
+      /**
+       * The generated text response from the model
+       */
+      response: string;
+      /**
+       * Usage statistics for the inference request
+       */
+      usage?: {
         /**
          * Total number of tokens in input
          */
@@ -3851,11 +4254,11 @@ type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output = {
          * Total number of input and output tokens
          */
         total_tokens?: number;
-    };
-    /**
-     * An array of tool calls requests made during the response generation
-     */
-    tool_calls?: {
+      };
+      /**
+       * An array of tool calls requests made during the response generation
+       */
+      tool_calls?: {
         /**
          * The arguments passed to be passed to the tool call request
          */
@@ -3864,46 +4267,50 @@ type Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output = {
          * The name of the tool to be called
          */
         name?: string;
-    }[];
-} | string | AsyncResponse;
+      }[];
+    }
+  | string
+  | AsyncResponse;
 declare abstract class Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast {
-    inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
-    postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
+  inputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Input;
+  postProcessedOutputs: Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Output;
 }
 interface Ai_Cf_Meta_Llama_Guard_3_8B_Input {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender must alternate between 'user' and 'assistant'.
      */
-    messages: {
-        /**
-         * The role of the message sender must alternate between 'user' and 'assistant'.
-         */
-        role: "user" | "assistant";
-        /**
-         * The content of the message as a string.
-         */
-        content: string;
-    }[];
+    role: "user" | "assistant";
     /**
-     * The maximum number of tokens to generate in the response.
+     * The content of the message as a string.
      */
-    max_tokens?: number;
+    content: string;
+  }[];
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Dictate the output format of the generated response.
+   */
+  response_format?: {
     /**
-     * Controls the randomness of the output; higher values produce more random results.
+     * Set to json_object to process and output generated text as JSON.
      */
-    temperature?: number;
-    /**
-     * Dictate the output format of the generated response.
-     */
-    response_format?: {
-        /**
-         * Set to json_object to process and output generated text as JSON.
-         */
-        type?: string;
-    };
+    type?: string;
+  };
 }
 interface Ai_Cf_Meta_Llama_Guard_3_8B_Output {
-    response?: string | {
+  response?:
+    | string
+    | {
         /**
          * Whether the conversation is safe or not.
          */
@@ -3912,137 +4319,140 @@ interface Ai_Cf_Meta_Llama_Guard_3_8B_Output {
          * A list of what hazard categories predicted for the conversation, if the conversation is deemed unsafe.
          */
         categories?: string[];
-    };
+      };
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
     /**
-     * Usage statistics for the inference request
+     * Total number of tokens in input
      */
-    usage?: {
-        /**
-         * Total number of tokens in input
-         */
-        prompt_tokens?: number;
-        /**
-         * Total number of tokens in output
-         */
-        completion_tokens?: number;
-        /**
-         * Total number of input and output tokens
-         */
-        total_tokens?: number;
-    };
+    prompt_tokens?: number;
+    /**
+     * Total number of tokens in output
+     */
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
 }
 declare abstract class Base_Ai_Cf_Meta_Llama_Guard_3_8B {
-    inputs: Ai_Cf_Meta_Llama_Guard_3_8B_Input;
-    postProcessedOutputs: Ai_Cf_Meta_Llama_Guard_3_8B_Output;
+  inputs: Ai_Cf_Meta_Llama_Guard_3_8B_Input;
+  postProcessedOutputs: Ai_Cf_Meta_Llama_Guard_3_8B_Output;
 }
 interface Ai_Cf_Baai_Bge_Reranker_Base_Input {
+  /**
+   * A query you wish to perform against the provided contexts.
+   */
+  /**
+   * Number of returned results starting with the best score.
+   */
+  top_k?: number;
+  /**
+   * List of provided contexts. Note that the index in this array is important, as the response will refer to it.
+   */
+  contexts: {
     /**
-     * A query you wish to perform against the provided contexts.
+     * One of the provided context content
      */
-    /**
-     * Number of returned results starting with the best score.
-     */
-    top_k?: number;
-    /**
-     * List of provided contexts. Note that the index in this array is important, as the response will refer to it.
-     */
-    contexts: {
-        /**
-         * One of the provided context content
-         */
-        text?: string;
-    }[];
+    text?: string;
+  }[];
 }
 interface Ai_Cf_Baai_Bge_Reranker_Base_Output {
-    response?: {
-        /**
-         * Index of the context in the request
-         */
-        id?: number;
-        /**
-         * Score of the context under the index.
-         */
-        score?: number;
-    }[];
+  response?: {
+    /**
+     * Index of the context in the request
+     */
+    id?: number;
+    /**
+     * Score of the context under the index.
+     */
+    score?: number;
+  }[];
 }
 declare abstract class Base_Ai_Cf_Baai_Bge_Reranker_Base {
-    inputs: Ai_Cf_Baai_Bge_Reranker_Base_Input;
-    postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
+  inputs: Ai_Cf_Baai_Bge_Reranker_Base_Input;
+  postProcessedOutputs: Ai_Cf_Baai_Bge_Reranker_Base_Output;
 }
-type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input = Qwen2_5_Coder_32B_Instruct_Prompt | Qwen2_5_Coder_32B_Instruct_Messages;
+type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input =
+  | Qwen2_5_Coder_32B_Instruct_Prompt
+  | Qwen2_5_Coder_32B_Instruct_Messages;
 interface Qwen2_5_Coder_32B_Instruct_Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
-     */
-    lora?: string;
-    response_format?: JSONMode;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model.
+   */
+  lora?: string;
+  response_format?: JSONMode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Qwen2_5_Coder_32B_Instruct_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role: string;
-        /**
-         * The content of the message as a string.
-         */
-        content: string;
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
+    role: string;
     /**
-     * A list of tools available for the assistant to use.
+     * The content of the message as a string.
      */
-    tools?: ({
+    content: string;
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -4055,6 +4465,52 @@ interface Qwen2_5_Coder_32B_Instruct_Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -4067,245 +4523,205 @@ interface Qwen2_5_Coder_32B_Instruct_Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    response_format?: JSONMode;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  response_format?: JSONMode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 type Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output = {
+  /**
+   * The generated text response from the model
+   */
+  response: string;
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
     /**
-     * The generated text response from the model
+     * Total number of tokens in input
      */
-    response: string;
+    prompt_tokens?: number;
     /**
-     * Usage statistics for the inference request
+     * Total number of tokens in output
      */
-    usage?: {
-        /**
-         * Total number of tokens in input
-         */
-        prompt_tokens?: number;
-        /**
-         * Total number of tokens in output
-         */
-        completion_tokens?: number;
-        /**
-         * Total number of input and output tokens
-         */
-        total_tokens?: number;
-    };
+    completion_tokens?: number;
     /**
-     * An array of tool calls requests made during the response generation
+     * Total number of input and output tokens
      */
-    tool_calls?: {
-        /**
-         * The arguments passed to be passed to the tool call request
-         */
-        arguments?: object;
-        /**
-         * The name of the tool to be called
-         */
-        name?: string;
-    }[];
+    total_tokens?: number;
+  };
+  /**
+   * An array of tool calls requests made during the response generation
+   */
+  tool_calls?: {
+    /**
+     * The arguments passed to be passed to the tool call request
+     */
+    arguments?: object;
+    /**
+     * The name of the tool to be called
+     */
+    name?: string;
+  }[];
 };
 declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
-    inputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input;
-    postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
+  inputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
 type Ai_Cf_Qwen_Qwq_32B_Input = Qwen_Qwq_32B_Prompt | Qwen_Qwq_32B_Messages;
 interface Qwen_Qwq_32B_Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * JSON schema that should be fulfilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * JSON schema that should be fulfilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Qwen_Qwq_32B_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role?: string;
-        /**
-         * The tool call id. Must be supplied for tool calls for Mistral-3. If you don't know what to put here you can fall back to 000000001
-         */
-        tool_call_id?: string;
-        content?: string | {
+    role?: string;
+    /**
+     * The tool call id. Must be supplied for tool calls for Mistral-3. If you don't know what to put here you can fall back to 000000001
+     */
+    tool_call_id?: string;
+    content?:
+      | string
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
-        }[] | {
+            url?: string;
+          };
+        }[]
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
+            url?: string;
+          };
         };
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
-    /**
-     * A list of tools available for the assistant to use.
-     */
-    tools?: ({
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -4318,6 +4734,52 @@ interface Qwen_Qwq_32B_Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -4330,248 +4792,210 @@ interface Qwen_Qwq_32B_Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    /**
-     * JSON schema that should be fufilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  /**
+   * JSON schema that should be fufilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 type Ai_Cf_Qwen_Qwq_32B_Output = {
+  /**
+   * The generated text response from the model
+   */
+  response: string;
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
     /**
-     * The generated text response from the model
+     * Total number of tokens in input
      */
-    response: string;
+    prompt_tokens?: number;
     /**
-     * Usage statistics for the inference request
+     * Total number of tokens in output
      */
-    usage?: {
-        /**
-         * Total number of tokens in input
-         */
-        prompt_tokens?: number;
-        /**
-         * Total number of tokens in output
-         */
-        completion_tokens?: number;
-        /**
-         * Total number of input and output tokens
-         */
-        total_tokens?: number;
-    };
+    completion_tokens?: number;
     /**
-     * An array of tool calls requests made during the response generation
+     * Total number of input and output tokens
      */
-    tool_calls?: {
-        /**
-         * The arguments passed to be passed to the tool call request
-         */
-        arguments?: object;
-        /**
-         * The name of the tool to be called
-         */
-        name?: string;
-    }[];
+    total_tokens?: number;
+  };
+  /**
+   * An array of tool calls requests made during the response generation
+   */
+  tool_calls?: {
+    /**
+     * The arguments passed to be passed to the tool call request
+     */
+    arguments?: object;
+    /**
+     * The name of the tool to be called
+     */
+    name?: string;
+  }[];
 };
 declare abstract class Base_Ai_Cf_Qwen_Qwq_32B {
-    inputs: Ai_Cf_Qwen_Qwq_32B_Input;
-    postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
+  inputs: Ai_Cf_Qwen_Qwq_32B_Input;
+  postProcessedOutputs: Ai_Cf_Qwen_Qwq_32B_Output;
 }
-type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input = Mistral_Small_3_1_24B_Instruct_Prompt | Mistral_Small_3_1_24B_Instruct_Messages;
+type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input =
+  | Mistral_Small_3_1_24B_Instruct_Prompt
+  | Mistral_Small_3_1_24B_Instruct_Messages;
 interface Mistral_Small_3_1_24B_Instruct_Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * JSON schema that should be fulfilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * JSON schema that should be fulfilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Mistral_Small_3_1_24B_Instruct_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role?: string;
-        /**
-         * The tool call id. Must be supplied for tool calls for Mistral-3. If you don't know what to put here you can fall back to 000000001
-         */
-        tool_call_id?: string;
-        content?: string | {
+    role?: string;
+    /**
+     * The tool call id. Must be supplied for tool calls for Mistral-3. If you don't know what to put here you can fall back to 000000001
+     */
+    tool_call_id?: string;
+    content?:
+      | string
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
-        }[] | {
+            url?: string;
+          };
+        }[]
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
+            url?: string;
+          };
         };
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
-    /**
-     * A list of tools available for the assistant to use.
-     */
-    tools?: ({
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -4584,6 +5008,52 @@ interface Mistral_Small_3_1_24B_Instruct_Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -4596,244 +5066,206 @@ interface Mistral_Small_3_1_24B_Instruct_Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    /**
-     * JSON schema that should be fufilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  /**
+   * JSON schema that should be fufilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 type Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output = {
+  /**
+   * The generated text response from the model
+   */
+  response: string;
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
     /**
-     * The generated text response from the model
+     * Total number of tokens in input
      */
-    response: string;
+    prompt_tokens?: number;
     /**
-     * Usage statistics for the inference request
+     * Total number of tokens in output
      */
-    usage?: {
-        /**
-         * Total number of tokens in input
-         */
-        prompt_tokens?: number;
-        /**
-         * Total number of tokens in output
-         */
-        completion_tokens?: number;
-        /**
-         * Total number of input and output tokens
-         */
-        total_tokens?: number;
-    };
+    completion_tokens?: number;
     /**
-     * An array of tool calls requests made during the response generation
+     * Total number of input and output tokens
      */
-    tool_calls?: {
-        /**
-         * The arguments passed to be passed to the tool call request
-         */
-        arguments?: object;
-        /**
-         * The name of the tool to be called
-         */
-        name?: string;
-    }[];
+    total_tokens?: number;
+  };
+  /**
+   * An array of tool calls requests made during the response generation
+   */
+  tool_calls?: {
+    /**
+     * The arguments passed to be passed to the tool call request
+     */
+    arguments?: object;
+    /**
+     * The name of the tool to be called
+     */
+    name?: string;
+  }[];
 };
 declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct {
-    inputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input;
-    postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
+  inputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Input;
+  postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
-type Ai_Cf_Google_Gemma_3_12B_It_Input = Google_Gemma_3_12B_It_Prompt | Google_Gemma_3_12B_It_Messages;
+type Ai_Cf_Google_Gemma_3_12B_It_Input =
+  | Google_Gemma_3_12B_It_Prompt
+  | Google_Gemma_3_12B_It_Messages;
 interface Google_Gemma_3_12B_It_Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * JSON schema that should be fufilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * JSON schema that should be fufilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Google_Gemma_3_12B_It_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role?: string;
-        content?: string | {
+    role?: string;
+    content?:
+      | string
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
-        }[] | {
+            url?: string;
+          };
+        }[]
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
+            url?: string;
+          };
         };
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
-    /**
-     * A list of tools available for the assistant to use.
-     */
-    tools?: ({
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -4846,6 +5278,52 @@ interface Google_Gemma_3_12B_It_Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -4858,249 +5336,212 @@ interface Google_Gemma_3_12B_It_Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    /**
-     * JSON schema that should be fufilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  /**
+   * JSON schema that should be fufilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 type Ai_Cf_Google_Gemma_3_12B_It_Output = {
+  /**
+   * The generated text response from the model
+   */
+  response: string;
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
     /**
-     * The generated text response from the model
+     * Total number of tokens in input
      */
-    response: string;
+    prompt_tokens?: number;
     /**
-     * Usage statistics for the inference request
+     * Total number of tokens in output
      */
-    usage?: {
-        /**
-         * Total number of tokens in input
-         */
-        prompt_tokens?: number;
-        /**
-         * Total number of tokens in output
-         */
-        completion_tokens?: number;
-        /**
-         * Total number of input and output tokens
-         */
-        total_tokens?: number;
-    };
+    completion_tokens?: number;
     /**
-     * An array of tool calls requests made during the response generation
+     * Total number of input and output tokens
      */
-    tool_calls?: {
-        /**
-         * The arguments passed to be passed to the tool call request
-         */
-        arguments?: object;
-        /**
-         * The name of the tool to be called
-         */
-        name?: string;
-    }[];
+    total_tokens?: number;
+  };
+  /**
+   * An array of tool calls requests made during the response generation
+   */
+  tool_calls?: {
+    /**
+     * The arguments passed to be passed to the tool call request
+     */
+    arguments?: object;
+    /**
+     * The name of the tool to be called
+     */
+    name?: string;
+  }[];
 };
 declare abstract class Base_Ai_Cf_Google_Gemma_3_12B_It {
-    inputs: Ai_Cf_Google_Gemma_3_12B_It_Input;
-    postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
+  inputs: Ai_Cf_Google_Gemma_3_12B_It_Input;
+  postProcessedOutputs: Ai_Cf_Google_Gemma_3_12B_It_Output;
 }
-type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input = Ai_Cf_Meta_Llama_4_Prompt | Ai_Cf_Meta_Llama_4_Messages | Ai_Cf_Meta_Llama_4_Async_Batch;
+type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input =
+  | Ai_Cf_Meta_Llama_4_Prompt
+  | Ai_Cf_Meta_Llama_4_Messages
+  | Ai_Cf_Meta_Llama_4_Async_Batch;
 interface Ai_Cf_Meta_Llama_4_Prompt {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * JSON schema that should be fulfilled for the response.
-     */
-    guided_json?: object;
-    response_format?: JSONMode;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * JSON schema that should be fulfilled for the response.
+   */
+  guided_json?: object;
+  response_format?: JSONMode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Ai_Cf_Meta_Llama_4_Messages {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role?: string;
-        /**
-         * The tool call id. If you don't know what to put here you can fall back to 000000001
-         */
-        tool_call_id?: string;
-        content?: string | {
+    role?: string;
+    /**
+     * The tool call id. If you don't know what to put here you can fall back to 000000001
+     */
+    tool_call_id?: string;
+    content?:
+      | string
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
-        }[] | {
+            url?: string;
+          };
+        }[]
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
+            url?: string;
+          };
         };
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
-    /**
-     * A list of tools available for the assistant to use.
-     */
-    tools?: ({
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -5113,6 +5554,52 @@ interface Ai_Cf_Meta_Llama_4_Messages {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -5125,212 +5612,172 @@ interface Ai_Cf_Meta_Llama_4_Messages {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    response_format?: JSONMode;
-    /**
-     * JSON schema that should be fufilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  response_format?: JSONMode;
+  /**
+   * JSON schema that should be fufilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Ai_Cf_Meta_Llama_4_Async_Batch {
-    requests: (Ai_Cf_Meta_Llama_4_Prompt_Inner | Ai_Cf_Meta_Llama_4_Messages_Inner)[];
+  requests: (Ai_Cf_Meta_Llama_4_Prompt_Inner | Ai_Cf_Meta_Llama_4_Messages_Inner)[];
 }
 interface Ai_Cf_Meta_Llama_4_Prompt_Inner {
-    /**
-     * The input text prompt for the model to generate a response.
-     */
-    prompt: string;
-    /**
-     * JSON schema that should be fulfilled for the response.
-     */
-    guided_json?: object;
-    response_format?: JSONMode;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+  /**
+   * The input text prompt for the model to generate a response.
+   */
+  prompt: string;
+  /**
+   * JSON schema that should be fulfilled for the response.
+   */
+  guided_json?: object;
+  response_format?: JSONMode;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 interface Ai_Cf_Meta_Llama_4_Messages_Inner {
+  /**
+   * An array of message objects representing the conversation history.
+   */
+  messages: {
     /**
-     * An array of message objects representing the conversation history.
+     * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
      */
-    messages: {
-        /**
-         * The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool').
-         */
-        role?: string;
-        /**
-         * The tool call id. If you don't know what to put here you can fall back to 000000001
-         */
-        tool_call_id?: string;
-        content?: string | {
+    role?: string;
+    /**
+     * The tool call id. If you don't know what to put here you can fall back to 000000001
+     */
+    tool_call_id?: string;
+    content?:
+      | string
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
-        }[] | {
+            url?: string;
+          };
+        }[]
+      | {
+          /**
+           * Type of the content provided
+           */
+          type?: string;
+          text?: string;
+          image_url?: {
             /**
-             * Type of the content provided
+             * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
              */
-            type?: string;
-            text?: string;
-            image_url?: {
-                /**
-                 * image uri with data (e.g. data:image/jpeg;base64,/9j/...). HTTP URL will not be accepted
-                 */
-                url?: string;
-            };
+            url?: string;
+          };
         };
-    }[];
-    functions?: {
-        name: string;
-        code: string;
-    }[];
-    /**
-     * A list of tools available for the assistant to use.
-     */
-    tools?: ({
+  }[];
+  functions?: {
+    name: string;
+    code: string;
+  }[];
+  /**
+   * A list of tools available for the assistant to use.
+   */
+  tools?: (
+    | {
         /**
          * The name of the tool. More descriptive the better.
          */
@@ -5343,6 +5790,52 @@ interface Ai_Cf_Meta_Llama_4_Messages_Inner {
          * Schema defining the parameters accepted by the tool.
          */
         parameters: {
+          /**
+           * The type of the parameters object (usually 'object').
+           */
+          type: string;
+          /**
+           * List of required parameter names.
+           */
+          required?: string[];
+          /**
+           * Definitions of each parameter.
+           */
+          properties: {
+            [k: string]: {
+              /**
+               * The data type of the parameter.
+               */
+              type: string;
+              /**
+               * A description of the expected parameter.
+               */
+              description: string;
+            };
+          };
+        };
+      }
+    | {
+        /**
+         * Specifies the type of tool (e.g., 'function').
+         */
+        type: string;
+        /**
+         * Details of the function tool.
+         */
+        function: {
+          /**
+           * The name of the function.
+           */
+          name: string;
+          /**
+           * A brief description of what the function does.
+           */
+          description: string;
+          /**
+           * Schema defining the parameters accepted by the function.
+           */
+          parameters: {
             /**
              * The type of the parameters object (usually 'object').
              */
@@ -5355,967 +5848,986 @@ interface Ai_Cf_Meta_Llama_4_Messages_Inner {
              * Definitions of each parameter.
              */
             properties: {
-                [k: string]: {
-                    /**
-                     * The data type of the parameter.
-                     */
-                    type: string;
-                    /**
-                     * A description of the expected parameter.
-                     */
-                    description: string;
-                };
-            };
-        };
-    } | {
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type: string;
-        /**
-         * Details of the function tool.
-         */
-        function: {
-            /**
-             * The name of the function.
-             */
-            name: string;
-            /**
-             * A brief description of what the function does.
-             */
-            description: string;
-            /**
-             * Schema defining the parameters accepted by the function.
-             */
-            parameters: {
+              [k: string]: {
                 /**
-                 * The type of the parameters object (usually 'object').
+                 * The data type of the parameter.
                  */
                 type: string;
                 /**
-                 * List of required parameter names.
+                 * A description of the expected parameter.
                  */
-                required?: string[];
-                /**
-                 * Definitions of each parameter.
-                 */
-                properties: {
-                    [k: string]: {
-                        /**
-                         * The data type of the parameter.
-                         */
-                        type: string;
-                        /**
-                         * A description of the expected parameter.
-                         */
-                        description: string;
-                    };
-                };
+                description: string;
+              };
             };
+          };
         };
-    })[];
-    response_format?: JSONMode;
-    /**
-     * JSON schema that should be fufilled for the response.
-     */
-    guided_json?: object;
-    /**
-     * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
-     */
-    raw?: boolean;
-    /**
-     * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
-     */
-    stream?: boolean;
-    /**
-     * The maximum number of tokens to generate in the response.
-     */
-    max_tokens?: number;
-    /**
-     * Controls the randomness of the output; higher values produce more random results.
-     */
-    temperature?: number;
-    /**
-     * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
-     */
-    top_p?: number;
-    /**
-     * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
-     */
-    top_k?: number;
-    /**
-     * Random seed for reproducibility of the generation.
-     */
-    seed?: number;
-    /**
-     * Penalty for repeated tokens; higher values discourage repetition.
-     */
-    repetition_penalty?: number;
-    /**
-     * Decreases the likelihood of the model repeating the same lines verbatim.
-     */
-    frequency_penalty?: number;
-    /**
-     * Increases the likelihood of the model introducing new topics.
-     */
-    presence_penalty?: number;
+      }
+  )[];
+  response_format?: JSONMode;
+  /**
+   * JSON schema that should be fufilled for the response.
+   */
+  guided_json?: object;
+  /**
+   * If true, a chat template is not applied and you must adhere to the specific model's expected formatting.
+   */
+  raw?: boolean;
+  /**
+   * If true, the response will be streamed back incrementally using SSE, Server Sent Events.
+   */
+  stream?: boolean;
+  /**
+   * The maximum number of tokens to generate in the response.
+   */
+  max_tokens?: number;
+  /**
+   * Controls the randomness of the output; higher values produce more random results.
+   */
+  temperature?: number;
+  /**
+   * Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses.
+   */
+  top_p?: number;
+  /**
+   * Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises.
+   */
+  top_k?: number;
+  /**
+   * Random seed for reproducibility of the generation.
+   */
+  seed?: number;
+  /**
+   * Penalty for repeated tokens; higher values discourage repetition.
+   */
+  repetition_penalty?: number;
+  /**
+   * Decreases the likelihood of the model repeating the same lines verbatim.
+   */
+  frequency_penalty?: number;
+  /**
+   * Increases the likelihood of the model introducing new topics.
+   */
+  presence_penalty?: number;
 }
 type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output = {
+  /**
+   * The generated text response from the model
+   */
+  response: string;
+  /**
+   * Usage statistics for the inference request
+   */
+  usage?: {
     /**
-     * The generated text response from the model
+     * Total number of tokens in input
      */
-    response: string;
+    prompt_tokens?: number;
     /**
-     * Usage statistics for the inference request
+     * Total number of tokens in output
      */
-    usage?: {
-        /**
-         * Total number of tokens in input
-         */
-        prompt_tokens?: number;
-        /**
-         * Total number of tokens in output
-         */
-        completion_tokens?: number;
-        /**
-         * Total number of input and output tokens
-         */
-        total_tokens?: number;
+    completion_tokens?: number;
+    /**
+     * Total number of input and output tokens
+     */
+    total_tokens?: number;
+  };
+  /**
+   * An array of tool calls requests made during the response generation
+   */
+  tool_calls?: {
+    /**
+     * The tool call id.
+     */
+    id?: string;
+    /**
+     * Specifies the type of tool (e.g., 'function').
+     */
+    type?: string;
+    /**
+     * Details of the function tool.
+     */
+    function?: {
+      /**
+       * The name of the tool to be called
+       */
+      name?: string;
+      /**
+       * The arguments passed to be passed to the tool call request
+       */
+      arguments?: object;
     };
-    /**
-     * An array of tool calls requests made during the response generation
-     */
-    tool_calls?: {
-        /**
-         * The tool call id.
-         */
-        id?: string;
-        /**
-         * Specifies the type of tool (e.g., 'function').
-         */
-        type?: string;
-        /**
-         * Details of the function tool.
-         */
-        function?: {
-            /**
-             * The name of the tool to be called
-             */
-            name?: string;
-            /**
-             * The arguments passed to be passed to the tool call request
-             */
-            arguments?: object;
-        };
-    }[];
+  }[];
 };
 declare abstract class Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct {
-    inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
-    postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
+  inputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Input;
+  postProcessedOutputs: Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Output;
 }
 interface Ai_Cf_Deepgram_Nova_3_Input {
-    audio: {
-        body: object;
-        contentType: string;
-    };
-    /**
-     * Sets how the model will interpret strings submitted to the custom_topic param. When strict, the model will only return topics submitted using the custom_topic param. When extended, the model will return its own detected topics in addition to those submitted using the custom_topic param.
-     */
-    custom_topic_mode?: "extended" | "strict";
-    /**
-     * Custom topics you want the model to detect within your input audio or text if present Submit up to 100
-     */
-    custom_topic?: string;
-    /**
-     * Sets how the model will interpret intents submitted to the custom_intent param. When strict, the model will only return intents submitted using the custom_intent param. When extended, the model will return its own detected intents in addition those submitted using the custom_intents param
-     */
-    custom_intent_mode?: "extended" | "strict";
-    /**
-     * Custom intents you want the model to detect within your input audio if present
-     */
-    custom_intent?: string;
-    /**
-     * Identifies and extracts key entities from content in submitted audio
-     */
-    detect_entities?: boolean;
-    /**
-     * Identifies the dominant language spoken in submitted audio
-     */
-    detect_language?: boolean;
-    /**
-     * Recognize speaker changes. Each word in the transcript will be assigned a speaker number starting at 0
-     */
-    diarize?: boolean;
-    /**
-     * Identify and extract key entities from content in submitted audio
-     */
-    dictation?: boolean;
-    /**
-     * Specify the expected encoding of your submitted audio
-     */
-    encoding?: "linear16" | "flac" | "mulaw" | "amr-nb" | "amr-wb" | "opus" | "speex" | "g729";
-    /**
-     * Arbitrary key-value pairs that are attached to the API response for usage in downstream processing
-     */
-    extra?: string;
-    /**
-     * Filler Words can help transcribe interruptions in your audio, like 'uh' and 'um'
-     */
-    filler_words?: boolean;
-    /**
-     * Key term prompting can boost or suppress specialized terminology and brands.
-     */
-    keyterm?: string;
-    /**
-     * Keywords can boost or suppress specialized terminology and brands.
-     */
-    keywords?: string;
-    /**
-     * The BCP-47 language tag that hints at the primary spoken language. Depending on the Model and API endpoint you choose only certain languages are available.
-     */
-    language?: string;
-    /**
-     * Spoken measurements will be converted to their corresponding abbreviations.
-     */
-    measurements?: boolean;
-    /**
-     * Opts out requests from the Deepgram Model Improvement Program. Refer to our Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip.
-     */
-    mip_opt_out?: boolean;
-    /**
-     * Mode of operation for the model representing broad area of topic that will be talked about in the supplied audio
-     */
-    mode?: "general" | "medical" | "finance";
-    /**
-     * Transcribe each audio channel independently.
-     */
-    multichannel?: boolean;
-    /**
-     * Numerals converts numbers from written format to numerical format.
-     */
-    numerals?: boolean;
-    /**
-     * Splits audio into paragraphs to improve transcript readability.
-     */
-    paragraphs?: boolean;
-    /**
-     * Profanity Filter looks for recognized profanity and converts it to the nearest recognized non-profane word or removes it from the transcript completely.
-     */
-    profanity_filter?: boolean;
-    /**
-     * Add punctuation and capitalization to the transcript.
-     */
-    punctuate?: boolean;
-    /**
-     * Redaction removes sensitive information from your transcripts.
-     */
-    redact?: string;
-    /**
-     * Search for terms or phrases in submitted audio and replaces them.
-     */
-    replace?: string;
-    /**
-     * Search for terms or phrases in submitted audio.
-     */
-    search?: string;
-    /**
-     * Recognizes the sentiment throughout a transcript or text.
-     */
-    sentiment?: boolean;
-    /**
-     * Apply formatting to transcript output. When set to true, additional formatting will be applied to transcripts to improve readability.
-     */
-    smart_format?: boolean;
-    /**
-     * Detect topics throughout a transcript or text.
-     */
-    topics?: boolean;
-    /**
-     * Segments speech into meaningful semantic units.
-     */
-    utterances?: boolean;
-    /**
-     * Seconds to wait before detecting a pause between words in submitted audio.
-     */
-    utt_split?: number;
-    /**
-     * The number of channels in the submitted audio
-     */
-    channels?: number;
-    /**
-     * Specifies whether the streaming endpoint should provide ongoing transcription updates as more audio is received. When set to true, the endpoint sends continuous updates, meaning transcription results may evolve over time. Note: Supported only for webosockets.
-     */
-    interim_results?: boolean;
-    /**
-     * Indicates how long model will wait to detect whether a speaker has finished speaking or pauses for a significant period of time. When set to a value, the streaming endpoint immediately finalizes the transcription for the processed time range and returns the transcript with a speech_final parameter set to true. Can also be set to false to disable endpointing
-     */
-    endpointing?: string;
-    /**
-     * Indicates that speech has started. You'll begin receiving Speech Started messages upon speech starting. Note: Supported only for webosockets.
-     */
-    vad_events?: boolean;
-    /**
-     * Indicates how long model will wait to send an UtteranceEnd message after a word has been transcribed. Use with interim_results. Note: Supported only for webosockets.
-     */
-    utterance_end_ms?: boolean;
+  audio: {
+    body: object;
+    contentType: string;
+  };
+  /**
+   * Sets how the model will interpret strings submitted to the custom_topic param. When strict, the model will only return topics submitted using the custom_topic param. When extended, the model will return its own detected topics in addition to those submitted using the custom_topic param.
+   */
+  custom_topic_mode?: "extended" | "strict";
+  /**
+   * Custom topics you want the model to detect within your input audio or text if present Submit up to 100
+   */
+  custom_topic?: string;
+  /**
+   * Sets how the model will interpret intents submitted to the custom_intent param. When strict, the model will only return intents submitted using the custom_intent param. When extended, the model will return its own detected intents in addition those submitted using the custom_intents param
+   */
+  custom_intent_mode?: "extended" | "strict";
+  /**
+   * Custom intents you want the model to detect within your input audio if present
+   */
+  custom_intent?: string;
+  /**
+   * Identifies and extracts key entities from content in submitted audio
+   */
+  detect_entities?: boolean;
+  /**
+   * Identifies the dominant language spoken in submitted audio
+   */
+  detect_language?: boolean;
+  /**
+   * Recognize speaker changes. Each word in the transcript will be assigned a speaker number starting at 0
+   */
+  diarize?: boolean;
+  /**
+   * Identify and extract key entities from content in submitted audio
+   */
+  dictation?: boolean;
+  /**
+   * Specify the expected encoding of your submitted audio
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "amr-nb" | "amr-wb" | "opus" | "speex" | "g729";
+  /**
+   * Arbitrary key-value pairs that are attached to the API response for usage in downstream processing
+   */
+  extra?: string;
+  /**
+   * Filler Words can help transcribe interruptions in your audio, like 'uh' and 'um'
+   */
+  filler_words?: boolean;
+  /**
+   * Key term prompting can boost or suppress specialized terminology and brands.
+   */
+  keyterm?: string;
+  /**
+   * Keywords can boost or suppress specialized terminology and brands.
+   */
+  keywords?: string;
+  /**
+   * The BCP-47 language tag that hints at the primary spoken language. Depending on the Model and API endpoint you choose only certain languages are available.
+   */
+  language?: string;
+  /**
+   * Spoken measurements will be converted to their corresponding abbreviations.
+   */
+  measurements?: boolean;
+  /**
+   * Opts out requests from the Deepgram Model Improvement Program. Refer to our Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip.
+   */
+  mip_opt_out?: boolean;
+  /**
+   * Mode of operation for the model representing broad area of topic that will be talked about in the supplied audio
+   */
+  mode?: "general" | "medical" | "finance";
+  /**
+   * Transcribe each audio channel independently.
+   */
+  multichannel?: boolean;
+  /**
+   * Numerals converts numbers from written format to numerical format.
+   */
+  numerals?: boolean;
+  /**
+   * Splits audio into paragraphs to improve transcript readability.
+   */
+  paragraphs?: boolean;
+  /**
+   * Profanity Filter looks for recognized profanity and converts it to the nearest recognized non-profane word or removes it from the transcript completely.
+   */
+  profanity_filter?: boolean;
+  /**
+   * Add punctuation and capitalization to the transcript.
+   */
+  punctuate?: boolean;
+  /**
+   * Redaction removes sensitive information from your transcripts.
+   */
+  redact?: string;
+  /**
+   * Search for terms or phrases in submitted audio and replaces them.
+   */
+  replace?: string;
+  /**
+   * Search for terms or phrases in submitted audio.
+   */
+  search?: string;
+  /**
+   * Recognizes the sentiment throughout a transcript or text.
+   */
+  sentiment?: boolean;
+  /**
+   * Apply formatting to transcript output. When set to true, additional formatting will be applied to transcripts to improve readability.
+   */
+  smart_format?: boolean;
+  /**
+   * Detect topics throughout a transcript or text.
+   */
+  topics?: boolean;
+  /**
+   * Segments speech into meaningful semantic units.
+   */
+  utterances?: boolean;
+  /**
+   * Seconds to wait before detecting a pause between words in submitted audio.
+   */
+  utt_split?: number;
+  /**
+   * The number of channels in the submitted audio
+   */
+  channels?: number;
+  /**
+   * Specifies whether the streaming endpoint should provide ongoing transcription updates as more audio is received. When set to true, the endpoint sends continuous updates, meaning transcription results may evolve over time. Note: Supported only for webosockets.
+   */
+  interim_results?: boolean;
+  /**
+   * Indicates how long model will wait to detect whether a speaker has finished speaking or pauses for a significant period of time. When set to a value, the streaming endpoint immediately finalizes the transcription for the processed time range and returns the transcript with a speech_final parameter set to true. Can also be set to false to disable endpointing
+   */
+  endpointing?: string;
+  /**
+   * Indicates that speech has started. You'll begin receiving Speech Started messages upon speech starting. Note: Supported only for webosockets.
+   */
+  vad_events?: boolean;
+  /**
+   * Indicates how long model will wait to send an UtteranceEnd message after a word has been transcribed. Use with interim_results. Note: Supported only for webosockets.
+   */
+  utterance_end_ms?: boolean;
 }
 interface Ai_Cf_Deepgram_Nova_3_Output {
-    results?: {
-        channels?: {
-            alternatives?: {
-                confidence?: number;
-                transcript?: string;
-                words?: {
-                    confidence?: number;
-                    end?: number;
-                    start?: number;
-                    word?: string;
-                }[];
-            }[];
+  results?: {
+    channels?: {
+      alternatives?: {
+        confidence?: number;
+        transcript?: string;
+        words?: {
+          confidence?: number;
+          end?: number;
+          start?: number;
+          word?: string;
         }[];
-        summary?: {
-            result?: string;
-            short?: string;
-        };
-        sentiments?: {
-            segments?: {
-                text?: string;
-                start_word?: number;
-                end_word?: number;
-                sentiment?: string;
-                sentiment_score?: number;
-            }[];
-            average?: {
-                sentiment?: string;
-                sentiment_score?: number;
-            };
-        };
+      }[];
+    }[];
+    summary?: {
+      result?: string;
+      short?: string;
     };
+    sentiments?: {
+      segments?: {
+        text?: string;
+        start_word?: number;
+        end_word?: number;
+        sentiment?: string;
+        sentiment_score?: number;
+      }[];
+      average?: {
+        sentiment?: string;
+        sentiment_score?: number;
+      };
+    };
+  };
 }
 declare abstract class Base_Ai_Cf_Deepgram_Nova_3 {
-    inputs: Ai_Cf_Deepgram_Nova_3_Input;
-    postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
+  inputs: Ai_Cf_Deepgram_Nova_3_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Nova_3_Output;
 }
-type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input = {
-    /**
-     * readable stream with audio data and content-type specified for that data
-     */
-    audio: {
+type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input =
+  | {
+      /**
+       * readable stream with audio data and content-type specified for that data
+       */
+      audio: {
         body: object;
         contentType: string;
+      };
+      /**
+       * type of data PCM data that's sent to the inference server as raw array
+       */
+      dtype?: "uint8" | "float32" | "float64";
+    }
+  | {
+      /**
+       * base64 encoded audio data
+       */
+      audio: string;
+      /**
+       * type of data PCM data that's sent to the inference server as raw array
+       */
+      dtype?: "uint8" | "float32" | "float64";
     };
-    /**
-     * type of data PCM data that's sent to the inference server as raw array
-     */
-    dtype?: "uint8" | "float32" | "float64";
-} | {
-    /**
-     * base64 encoded audio data
-     */
-    audio: string;
-    /**
-     * type of data PCM data that's sent to the inference server as raw array
-     */
-    dtype?: "uint8" | "float32" | "float64";
-};
 interface Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output {
-    /**
-     * if true, end-of-turn was detected
-     */
-    is_complete?: boolean;
-    /**
-     * probability of the end-of-turn detection
-     */
-    probability?: number;
+  /**
+   * if true, end-of-turn was detected
+   */
+  is_complete?: boolean;
+  /**
+   * probability of the end-of-turn detection
+   */
+  probability?: number;
 }
 declare abstract class Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2 {
-    inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
-    postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
+  inputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
+  postProcessedOutputs: Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Output;
 }
 type Ai_Cf_Openai_Gpt_Oss_120B_Input = GPT_OSS_120B_Responses | GPT_OSS_120B_Responses_Async;
 interface GPT_OSS_120B_Responses {
+  /**
+   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
+   */
+  input: string | unknown[];
+  reasoning?: {
+    /**
+     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+     */
+    effort?: "low" | "medium" | "high";
+    /**
+     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
+     */
+    summary?: "auto" | "concise" | "detailed";
+  };
+}
+interface GPT_OSS_120B_Responses_Async {
+  requests: {
     /**
      * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
      */
     input: string | unknown[];
     reasoning?: {
-        /**
-         * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-         */
-        effort?: "low" | "medium" | "high";
-        /**
-         * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-         */
-        summary?: "auto" | "concise" | "detailed";
+      /**
+       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+       */
+      effort?: "low" | "medium" | "high";
+      /**
+       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
+       */
+      summary?: "auto" | "concise" | "detailed";
     };
-}
-interface GPT_OSS_120B_Responses_Async {
-    requests: {
-        /**
-         * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-         */
-        input: string | unknown[];
-        reasoning?: {
-            /**
-             * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-             */
-            effort?: "low" | "medium" | "high";
-            /**
-             * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-             */
-            summary?: "auto" | "concise" | "detailed";
-        };
-    }[];
+  }[];
 }
 type Ai_Cf_Openai_Gpt_Oss_120B_Output = {} | (string & NonNullable<unknown>);
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_120B {
-    inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
-    postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
+  inputs: Ai_Cf_Openai_Gpt_Oss_120B_Input;
+  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_120B_Output;
 }
 type Ai_Cf_Openai_Gpt_Oss_20B_Input = GPT_OSS_20B_Responses | GPT_OSS_20B_Responses_Async;
 interface GPT_OSS_20B_Responses {
+  /**
+   * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
+   */
+  input: string | unknown[];
+  reasoning?: {
+    /**
+     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+     */
+    effort?: "low" | "medium" | "high";
+    /**
+     * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
+     */
+    summary?: "auto" | "concise" | "detailed";
+  };
+}
+interface GPT_OSS_20B_Responses_Async {
+  requests: {
     /**
      * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
      */
     input: string | unknown[];
     reasoning?: {
-        /**
-         * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-         */
-        effort?: "low" | "medium" | "high";
-        /**
-         * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-         */
-        summary?: "auto" | "concise" | "detailed";
+      /**
+       * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+       */
+      effort?: "low" | "medium" | "high";
+      /**
+       * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
+       */
+      summary?: "auto" | "concise" | "detailed";
     };
-}
-interface GPT_OSS_20B_Responses_Async {
-    requests: {
-        /**
-         * Responses API Input messages. Refer to OpenAI Responses API docs to learn more about supported content types
-         */
-        input: string | unknown[];
-        reasoning?: {
-            /**
-             * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
-             */
-            effort?: "low" | "medium" | "high";
-            /**
-             * A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model's reasoning process. One of auto, concise, or detailed.
-             */
-            summary?: "auto" | "concise" | "detailed";
-        };
-    }[];
+  }[];
 }
 type Ai_Cf_Openai_Gpt_Oss_20B_Output = {} | (string & NonNullable<unknown>);
 declare abstract class Base_Ai_Cf_Openai_Gpt_Oss_20B {
-    inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
-    postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
+  inputs: Ai_Cf_Openai_Gpt_Oss_20B_Input;
+  postProcessedOutputs: Ai_Cf_Openai_Gpt_Oss_20B_Output;
 }
 interface Ai_Cf_Leonardo_Phoenix_1_0_Input {
-    /**
-     * A text description of the image you want to generate.
-     */
-    prompt: string;
-    /**
-     * Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt
-     */
-    guidance?: number;
-    /**
-     * Random seed for reproducibility of the image generation
-     */
-    seed?: number;
-    /**
-     * The height of the generated image in pixels
-     */
-    height?: number;
-    /**
-     * The width of the generated image in pixels
-     */
-    width?: number;
-    /**
-     * The number of diffusion steps; higher values can improve quality but take longer
-     */
-    num_steps?: number;
-    /**
-     * Specify what to exclude from the generated images
-     */
-    negative_prompt?: string;
+  /**
+   * A text description of the image you want to generate.
+   */
+  prompt: string;
+  /**
+   * Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt
+   */
+  guidance?: number;
+  /**
+   * Random seed for reproducibility of the image generation
+   */
+  seed?: number;
+  /**
+   * The height of the generated image in pixels
+   */
+  height?: number;
+  /**
+   * The width of the generated image in pixels
+   */
+  width?: number;
+  /**
+   * The number of diffusion steps; higher values can improve quality but take longer
+   */
+  num_steps?: number;
+  /**
+   * Specify what to exclude from the generated images
+   */
+  negative_prompt?: string;
 }
 /**
  * The generated image in JPEG format
  */
 type Ai_Cf_Leonardo_Phoenix_1_0_Output = string;
 declare abstract class Base_Ai_Cf_Leonardo_Phoenix_1_0 {
-    inputs: Ai_Cf_Leonardo_Phoenix_1_0_Input;
-    postProcessedOutputs: Ai_Cf_Leonardo_Phoenix_1_0_Output;
+  inputs: Ai_Cf_Leonardo_Phoenix_1_0_Input;
+  postProcessedOutputs: Ai_Cf_Leonardo_Phoenix_1_0_Output;
 }
 interface Ai_Cf_Leonardo_Lucid_Origin_Input {
-    /**
-     * A text description of the image you want to generate.
-     */
-    prompt: string;
-    /**
-     * Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt
-     */
-    guidance?: number;
-    /**
-     * Random seed for reproducibility of the image generation
-     */
-    seed?: number;
-    /**
-     * The height of the generated image in pixels
-     */
-    height?: number;
-    /**
-     * The width of the generated image in pixels
-     */
-    width?: number;
-    /**
-     * The number of diffusion steps; higher values can improve quality but take longer
-     */
-    num_steps?: number;
-    /**
-     * The number of diffusion steps; higher values can improve quality but take longer
-     */
-    steps?: number;
+  /**
+   * A text description of the image you want to generate.
+   */
+  prompt: string;
+  /**
+   * Controls how closely the generated image should adhere to the prompt; higher values make the image more aligned with the prompt
+   */
+  guidance?: number;
+  /**
+   * Random seed for reproducibility of the image generation
+   */
+  seed?: number;
+  /**
+   * The height of the generated image in pixels
+   */
+  height?: number;
+  /**
+   * The width of the generated image in pixels
+   */
+  width?: number;
+  /**
+   * The number of diffusion steps; higher values can improve quality but take longer
+   */
+  num_steps?: number;
+  /**
+   * The number of diffusion steps; higher values can improve quality but take longer
+   */
+  steps?: number;
 }
 interface Ai_Cf_Leonardo_Lucid_Origin_Output {
-    /**
-     * The generated image in Base64 format.
-     */
-    image?: string;
+  /**
+   * The generated image in Base64 format.
+   */
+  image?: string;
 }
 declare abstract class Base_Ai_Cf_Leonardo_Lucid_Origin {
-    inputs: Ai_Cf_Leonardo_Lucid_Origin_Input;
-    postProcessedOutputs: Ai_Cf_Leonardo_Lucid_Origin_Output;
+  inputs: Ai_Cf_Leonardo_Lucid_Origin_Input;
+  postProcessedOutputs: Ai_Cf_Leonardo_Lucid_Origin_Output;
 }
 interface Ai_Cf_Deepgram_Aura_1_Input {
-    /**
-     * Speaker used to produce the audio.
-     */
-    speaker?: "angus" | "asteria" | "arcas" | "orion" | "orpheus" | "athena" | "luna" | "zeus" | "perseus" | "helios" | "hera" | "stella";
-    /**
-     * Encoding of the output audio.
-     */
-    encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
-    /**
-     * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
-     */
-    container?: "none" | "wav" | "ogg";
-    /**
-     * The text content to be converted to speech
-     */
-    text: string;
-    /**
-     * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
-     */
-    sample_rate?: number;
-    /**
-     * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
-     */
-    bit_rate?: number;
+  /**
+   * Speaker used to produce the audio.
+   */
+  speaker?:
+    | "angus"
+    | "asteria"
+    | "arcas"
+    | "orion"
+    | "orpheus"
+    | "athena"
+    | "luna"
+    | "zeus"
+    | "perseus"
+    | "helios"
+    | "hera"
+    | "stella";
+  /**
+   * Encoding of the output audio.
+   */
+  encoding?: "linear16" | "flac" | "mulaw" | "alaw" | "mp3" | "opus" | "aac";
+  /**
+   * Container specifies the file format wrapper for the output audio. The available options depend on the encoding type..
+   */
+  container?: "none" | "wav" | "ogg";
+  /**
+   * The text content to be converted to speech
+   */
+  text: string;
+  /**
+   * Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+   */
+  sample_rate?: number;
+  /**
+   * The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+   */
+  bit_rate?: number;
 }
 /**
  * The generated audio in MP3 format
  */
 type Ai_Cf_Deepgram_Aura_1_Output = string;
 declare abstract class Base_Ai_Cf_Deepgram_Aura_1 {
-    inputs: Ai_Cf_Deepgram_Aura_1_Input;
-    postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
+  inputs: Ai_Cf_Deepgram_Aura_1_Input;
+  postProcessedOutputs: Ai_Cf_Deepgram_Aura_1_Output;
 }
 interface AiModels {
-    "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
-    "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
-    "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
-    "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
-    "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
-    "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
-    "@cf/myshell-ai/melotts": BaseAiTextToSpeech;
-    "@cf/google/embeddinggemma-300m": BaseAiTextEmbeddings;
-    "@cf/microsoft/resnet-50": BaseAiImageClassification;
-    "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
-    "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
-    "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
-    "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
-    "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
-    "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
-    "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
-    "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
-    "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
-    "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
-    "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
-    "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
-    "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
-    "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
-    "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
-    "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
-    "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
-    "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
-    "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
-    "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
-    "@cf/microsoft/phi-2": BaseAiTextGeneration;
-    "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
-    "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
-    "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
-    "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
-    "@hf/google/gemma-7b-it": BaseAiTextGeneration;
-    "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
-    "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
-    "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
-    "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
-    "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
-    "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
-    "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
-    "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
-    "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
-    "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
-    "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
-    "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
-    "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
-    "@cf/facebook/bart-large-cnn": BaseAiSummarization;
-    "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
-    "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
-    "@cf/openai/whisper": Base_Ai_Cf_Openai_Whisper;
-    "@cf/meta/m2m100-1.2b": Base_Ai_Cf_Meta_M2M100_1_2B;
-    "@cf/baai/bge-small-en-v1.5": Base_Ai_Cf_Baai_Bge_Small_En_V1_5;
-    "@cf/baai/bge-large-en-v1.5": Base_Ai_Cf_Baai_Bge_Large_En_V1_5;
-    "@cf/unum/uform-gen2-qwen-500m": Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M;
-    "@cf/openai/whisper-tiny-en": Base_Ai_Cf_Openai_Whisper_Tiny_En;
-    "@cf/openai/whisper-large-v3-turbo": Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo;
-    "@cf/baai/bge-m3": Base_Ai_Cf_Baai_Bge_M3;
-    "@cf/black-forest-labs/flux-1-schnell": Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell;
-    "@cf/meta/llama-3.2-11b-vision-instruct": Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct;
-    "@cf/meta/llama-3.3-70b-instruct-fp8-fast": Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast;
-    "@cf/meta/llama-guard-3-8b": Base_Ai_Cf_Meta_Llama_Guard_3_8B;
-    "@cf/baai/bge-reranker-base": Base_Ai_Cf_Baai_Bge_Reranker_Base;
-    "@cf/qwen/qwen2.5-coder-32b-instruct": Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct;
-    "@cf/qwen/qwq-32b": Base_Ai_Cf_Qwen_Qwq_32B;
-    "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
-    "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
-    "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
-    "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
-    "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
-    "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
-    "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
-    "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
-    "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
-    "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
+  "@cf/huggingface/distilbert-sst-2-int8": BaseAiTextClassification;
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-inpainting": BaseAiTextToImage;
+  "@cf/runwayml/stable-diffusion-v1-5-img2img": BaseAiTextToImage;
+  "@cf/lykon/dreamshaper-8-lcm": BaseAiTextToImage;
+  "@cf/bytedance/stable-diffusion-xl-lightning": BaseAiTextToImage;
+  "@cf/myshell-ai/melotts": BaseAiTextToSpeech;
+  "@cf/google/embeddinggemma-300m": BaseAiTextEmbeddings;
+  "@cf/microsoft/resnet-50": BaseAiImageClassification;
+  "@cf/meta/llama-2-7b-chat-int8": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.1": BaseAiTextGeneration;
+  "@cf/meta/llama-2-7b-chat-fp16": BaseAiTextGeneration;
+  "@hf/thebloke/llama-2-13b-chat-awq": BaseAiTextGeneration;
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/zephyr-7b-beta-awq": BaseAiTextGeneration;
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/neural-chat-7b-v3-1-awq": BaseAiTextGeneration;
+  "@hf/thebloke/llamaguard-7b-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq": BaseAiTextGeneration;
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-math-7b-instruct": BaseAiTextGeneration;
+  "@cf/defog/sqlcoder-7b-2": BaseAiTextGeneration;
+  "@cf/openchat/openchat-3.5-0106": BaseAiTextGeneration;
+  "@cf/tiiuae/falcon-7b-instruct": BaseAiTextGeneration;
+  "@cf/thebloke/discolm-german-7b-v1-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-0.5b-chat": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-7b-chat-awq": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-14b-chat-awq": BaseAiTextGeneration;
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": BaseAiTextGeneration;
+  "@cf/microsoft/phi-2": BaseAiTextGeneration;
+  "@cf/qwen/qwen1.5-1.8b-chat": BaseAiTextGeneration;
+  "@cf/mistral/mistral-7b-instruct-v0.2-lora": BaseAiTextGeneration;
+  "@hf/nousresearch/hermes-2-pro-mistral-7b": BaseAiTextGeneration;
+  "@hf/nexusflow/starling-lm-7b-beta": BaseAiTextGeneration;
+  "@hf/google/gemma-7b-it": BaseAiTextGeneration;
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-2b-it-lora": BaseAiTextGeneration;
+  "@cf/google/gemma-7b-it-lora": BaseAiTextGeneration;
+  "@hf/mistral/mistral-7b-instruct-v0.2": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/fblgit/una-cybertron-7b-v2-bf16": BaseAiTextGeneration;
+  "@cf/meta/llama-3-8b-instruct-awq": BaseAiTextGeneration;
+  "@hf/meta-llama/meta-llama-3-8b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-fp8": BaseAiTextGeneration;
+  "@cf/meta/llama-3.1-8b-instruct-awq": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-3b-instruct": BaseAiTextGeneration;
+  "@cf/meta/llama-3.2-1b-instruct": BaseAiTextGeneration;
+  "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": BaseAiTextGeneration;
+  "@cf/facebook/bart-large-cnn": BaseAiSummarization;
+  "@cf/llava-hf/llava-1.5-7b-hf": BaseAiImageToText;
+  "@cf/baai/bge-base-en-v1.5": Base_Ai_Cf_Baai_Bge_Base_En_V1_5;
+  "@cf/openai/whisper": Base_Ai_Cf_Openai_Whisper;
+  "@cf/meta/m2m100-1.2b": Base_Ai_Cf_Meta_M2M100_1_2B;
+  "@cf/baai/bge-small-en-v1.5": Base_Ai_Cf_Baai_Bge_Small_En_V1_5;
+  "@cf/baai/bge-large-en-v1.5": Base_Ai_Cf_Baai_Bge_Large_En_V1_5;
+  "@cf/unum/uform-gen2-qwen-500m": Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M;
+  "@cf/openai/whisper-tiny-en": Base_Ai_Cf_Openai_Whisper_Tiny_En;
+  "@cf/openai/whisper-large-v3-turbo": Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo;
+  "@cf/baai/bge-m3": Base_Ai_Cf_Baai_Bge_M3;
+  "@cf/black-forest-labs/flux-1-schnell": Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell;
+  "@cf/meta/llama-3.2-11b-vision-instruct": Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct;
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast;
+  "@cf/meta/llama-guard-3-8b": Base_Ai_Cf_Meta_Llama_Guard_3_8B;
+  "@cf/baai/bge-reranker-base": Base_Ai_Cf_Baai_Bge_Reranker_Base;
+  "@cf/qwen/qwen2.5-coder-32b-instruct": Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct;
+  "@cf/qwen/qwq-32b": Base_Ai_Cf_Qwen_Qwq_32B;
+  "@cf/mistralai/mistral-small-3.1-24b-instruct": Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct;
+  "@cf/google/gemma-3-12b-it": Base_Ai_Cf_Google_Gemma_3_12B_It;
+  "@cf/meta/llama-4-scout-17b-16e-instruct": Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
+  "@cf/deepgram/nova-3": Base_Ai_Cf_Deepgram_Nova_3;
+  "@cf/pipecat-ai/smart-turn-v2": Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
+  "@cf/openai/gpt-oss-120b": Base_Ai_Cf_Openai_Gpt_Oss_120B;
+  "@cf/openai/gpt-oss-20b": Base_Ai_Cf_Openai_Gpt_Oss_20B;
+  "@cf/leonardo/phoenix-1.0": Base_Ai_Cf_Leonardo_Phoenix_1_0;
+  "@cf/leonardo/lucid-origin": Base_Ai_Cf_Leonardo_Lucid_Origin;
+  "@cf/deepgram/aura-1": Base_Ai_Cf_Deepgram_Aura_1;
 }
 type AiOptions = {
-    /**
-     * Send requests as an asynchronous batch job, only works for supported models
-     * https://developers.cloudflare.com/workers-ai/features/batch-api
-     */
-    queueRequest?: boolean;
-    /**
-     * Establish websocket connections, only works for supported models
-     */
-    websocket?: boolean;
-    gateway?: GatewayOptions;
-    returnRawResponse?: boolean;
-    prefix?: string;
-    extraHeaders?: object;
+  /**
+   * Send requests as an asynchronous batch job, only works for supported models
+   * https://developers.cloudflare.com/workers-ai/features/batch-api
+   */
+  queueRequest?: boolean;
+  /**
+   * Establish websocket connections, only works for supported models
+   */
+  websocket?: boolean;
+  gateway?: GatewayOptions;
+  returnRawResponse?: boolean;
+  prefix?: string;
+  extraHeaders?: object;
 };
 type ConversionResponse = {
-    name: string;
-    mimeType: string;
-    format: "markdown";
-    tokens: number;
-    data: string;
+  name: string;
+  mimeType: string;
+  format: "markdown";
+  tokens: number;
+  data: string;
 };
 type AiModelsSearchParams = {
-    author?: string;
-    hide_experimental?: boolean;
-    page?: number;
-    per_page?: number;
-    search?: string;
-    source?: number;
-    task?: string;
+  author?: string;
+  hide_experimental?: boolean;
+  page?: number;
+  per_page?: number;
+  search?: string;
+  source?: number;
+  task?: string;
 };
 type AiModelsSearchObject = {
+  id: string;
+  source: number;
+  name: string;
+  description: string;
+  task: {
     id: string;
-    source: number;
     name: string;
     description: string;
-    task: {
-        id: string;
-        name: string;
-        description: string;
-    };
-    tags: string[];
-    properties: {
-        property_id: string;
-        value: string;
-    }[];
+  };
+  tags: string[];
+  properties: {
+    property_id: string;
+    value: string;
+  }[];
 };
-interface InferenceUpstreamError extends Error {
-}
-interface AiInternalError extends Error {
-}
+interface InferenceUpstreamError extends Error {}
+interface AiInternalError extends Error {}
 type AiModelListType = Record<string, any>;
 declare abstract class Ai<AiModelList extends AiModelListType = AiModels> {
-    aiGatewayLogId: string | null;
-    gateway(gatewayId: string): AiGateway;
-    autorag(autoragId: string): AutoRAG;
-    run<Name extends keyof AiModelList, Options extends AiOptions, InputOptions extends AiModelList[Name]["inputs"]>(model: Name, inputs: InputOptions, options?: Options): Promise<Options extends {
-        returnRawResponse: true;
-    } | {
-        websocket: true;
-    } ? Response : InputOptions extends {
-        stream: true;
-    } ? ReadableStream : AiModelList[Name]["postProcessedOutputs"]>;
-    models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
-    toMarkdown(files: {
-        name: string;
-        blob: Blob;
-    }[], options?: {
-        gateway?: GatewayOptions;
-        extraHeaders?: object;
-    }): Promise<ConversionResponse[]>;
-    toMarkdown(files: {
-        name: string;
-        blob: Blob;
-    }, options?: {
-        gateway?: GatewayOptions;
-        extraHeaders?: object;
-    }): Promise<ConversionResponse>;
+  aiGatewayLogId: string | null;
+  gateway(gatewayId: string): AiGateway;
+  autorag(autoragId: string): AutoRAG;
+  run<
+    Name extends keyof AiModelList,
+    Options extends AiOptions,
+    InputOptions extends AiModelList[Name]["inputs"],
+  >(
+    model: Name,
+    inputs: InputOptions,
+    options?: Options,
+  ): Promise<
+    Options extends
+      | {
+          returnRawResponse: true;
+        }
+      | {
+          websocket: true;
+        }
+      ? Response
+      : InputOptions extends {
+            stream: true;
+          }
+        ? ReadableStream
+        : AiModelList[Name]["postProcessedOutputs"]
+  >;
+  models(params?: AiModelsSearchParams): Promise<AiModelsSearchObject[]>;
+  toMarkdown(
+    files: {
+      name: string;
+      blob: Blob;
+    }[],
+    options?: {
+      gateway?: GatewayOptions;
+      extraHeaders?: object;
+    },
+  ): Promise<ConversionResponse[]>;
+  toMarkdown(
+    files: {
+      name: string;
+      blob: Blob;
+    },
+    options?: {
+      gateway?: GatewayOptions;
+      extraHeaders?: object;
+    },
+  ): Promise<ConversionResponse>;
 }
 type GatewayRetries = {
-    maxAttempts?: 1 | 2 | 3 | 4 | 5;
-    retryDelayMs?: number;
-    backoff?: 'constant' | 'linear' | 'exponential';
+  maxAttempts?: 1 | 2 | 3 | 4 | 5;
+  retryDelayMs?: number;
+  backoff?: "constant" | "linear" | "exponential";
 };
 type GatewayOptions = {
-    id: string;
-    cacheKey?: string;
-    cacheTtl?: number;
-    skipCache?: boolean;
-    metadata?: Record<string, number | string | boolean | null | bigint>;
-    collectLog?: boolean;
-    eventId?: string;
-    requestTimeoutMs?: number;
-    retries?: GatewayRetries;
+  id: string;
+  cacheKey?: string;
+  cacheTtl?: number;
+  skipCache?: boolean;
+  metadata?: Record<string, number | string | boolean | null | bigint>;
+  collectLog?: boolean;
+  eventId?: string;
+  requestTimeoutMs?: number;
+  retries?: GatewayRetries;
 };
-type UniversalGatewayOptions = Exclude<GatewayOptions, 'id'> & {
-    /**
-     ** @deprecated
-     */
-    id?: string;
+type UniversalGatewayOptions = Exclude<GatewayOptions, "id"> & {
+  /**
+   ** @deprecated
+   */
+  id?: string;
 };
 type AiGatewayPatchLog = {
-    score?: number | null;
-    feedback?: -1 | 1 | null;
-    metadata?: Record<string, number | string | boolean | null | bigint> | null;
+  score?: number | null;
+  feedback?: -1 | 1 | null;
+  metadata?: Record<string, number | string | boolean | null | bigint> | null;
 };
 type AiGatewayLog = {
-    id: string;
-    provider: string;
-    model: string;
-    model_type?: string;
-    path: string;
-    duration: number;
-    request_type?: string;
-    request_content_type?: string;
-    status_code: number;
-    response_content_type?: string;
-    success: boolean;
-    cached: boolean;
-    tokens_in?: number;
-    tokens_out?: number;
-    metadata?: Record<string, number | string | boolean | null | bigint>;
-    step?: number;
-    cost?: number;
-    custom_cost?: boolean;
-    request_size: number;
-    request_head?: string;
-    request_head_complete: boolean;
-    response_size: number;
-    response_head?: string;
-    response_head_complete: boolean;
-    created_at: Date;
+  id: string;
+  provider: string;
+  model: string;
+  model_type?: string;
+  path: string;
+  duration: number;
+  request_type?: string;
+  request_content_type?: string;
+  status_code: number;
+  response_content_type?: string;
+  success: boolean;
+  cached: boolean;
+  tokens_in?: number;
+  tokens_out?: number;
+  metadata?: Record<string, number | string | boolean | null | bigint>;
+  step?: number;
+  cost?: number;
+  custom_cost?: boolean;
+  request_size: number;
+  request_head?: string;
+  request_head_complete: boolean;
+  response_size: number;
+  response_head?: string;
+  response_head_complete: boolean;
+  created_at: Date;
 };
-type AIGatewayProviders = 'workers-ai' | 'anthropic' | 'aws-bedrock' | 'azure-openai' | 'google-vertex-ai' | 'huggingface' | 'openai' | 'perplexity-ai' | 'replicate' | 'groq' | 'cohere' | 'google-ai-studio' | 'mistral' | 'grok' | 'openrouter' | 'deepseek' | 'cerebras' | 'cartesia' | 'elevenlabs' | 'adobe-firefly';
+type AIGatewayProviders =
+  | "workers-ai"
+  | "anthropic"
+  | "aws-bedrock"
+  | "azure-openai"
+  | "google-vertex-ai"
+  | "huggingface"
+  | "openai"
+  | "perplexity-ai"
+  | "replicate"
+  | "groq"
+  | "cohere"
+  | "google-ai-studio"
+  | "mistral"
+  | "grok"
+  | "openrouter"
+  | "deepseek"
+  | "cerebras"
+  | "cartesia"
+  | "elevenlabs"
+  | "adobe-firefly";
 type AIGatewayHeaders = {
-    'cf-aig-metadata': Record<string, number | string | boolean | null | bigint> | string;
-    'cf-aig-custom-cost': {
+  "cf-aig-metadata": Record<string, number | string | boolean | null | bigint> | string;
+  "cf-aig-custom-cost":
+    | {
         per_token_in?: number;
         per_token_out?: number;
-    } | {
+      }
+    | {
         total_cost?: number;
-    } | string;
-    'cf-aig-cache-ttl': number | string;
-    'cf-aig-skip-cache': boolean | string;
-    'cf-aig-cache-key': string;
-    'cf-aig-event-id': string;
-    'cf-aig-request-timeout': number | string;
-    'cf-aig-max-attempts': number | string;
-    'cf-aig-retry-delay': number | string;
-    'cf-aig-backoff': string;
-    'cf-aig-collect-log': boolean | string;
-    Authorization: string;
-    'Content-Type': string;
-    [key: string]: string | number | boolean | object;
+      }
+    | string;
+  "cf-aig-cache-ttl": number | string;
+  "cf-aig-skip-cache": boolean | string;
+  "cf-aig-cache-key": string;
+  "cf-aig-event-id": string;
+  "cf-aig-request-timeout": number | string;
+  "cf-aig-max-attempts": number | string;
+  "cf-aig-retry-delay": number | string;
+  "cf-aig-backoff": string;
+  "cf-aig-collect-log": boolean | string;
+  Authorization: string;
+  "Content-Type": string;
+  [key: string]: string | number | boolean | object;
 };
 type AIGatewayUniversalRequest = {
-    provider: AIGatewayProviders | string; // eslint-disable-line
-    endpoint: string;
-    headers: Partial<AIGatewayHeaders>;
-    query: unknown;
+  provider: AIGatewayProviders | string;
+  endpoint: string;
+  headers: Partial<AIGatewayHeaders>;
+  query: unknown;
 };
-interface AiGatewayInternalError extends Error {
-}
-interface AiGatewayLogNotFound extends Error {
-}
+interface AiGatewayInternalError extends Error {}
+interface AiGatewayLogNotFound extends Error {}
 declare abstract class AiGateway {
-    patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
-    getLog(logId: string): Promise<AiGatewayLog>;
-    run(data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[], options?: {
-        gateway?: UniversalGatewayOptions;
-        extraHeaders?: object;
-    }): Promise<Response>;
-    getUrl(provider?: AIGatewayProviders | string): Promise<string>; // eslint-disable-line
+  patchLog(logId: string, data: AiGatewayPatchLog): Promise<void>;
+  getLog(logId: string): Promise<AiGatewayLog>;
+  run(
+    data: AIGatewayUniversalRequest | AIGatewayUniversalRequest[],
+    options?: {
+      gateway?: UniversalGatewayOptions;
+      extraHeaders?: object;
+    },
+  ): Promise<Response>;
+  getUrl(provider?: AIGatewayProviders | string): Promise<string>;
 }
-interface AutoRAGInternalError extends Error {
-}
-interface AutoRAGNotFoundError extends Error {
-}
-interface AutoRAGUnauthorizedError extends Error {
-}
-interface AutoRAGNameNotSetError extends Error {
-}
+interface AutoRAGInternalError extends Error {}
+interface AutoRAGNotFoundError extends Error {}
+interface AutoRAGUnauthorizedError extends Error {}
+interface AutoRAGNameNotSetError extends Error {}
 type ComparisonFilter = {
-    key: string;
-    type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
-    value: string | number | boolean;
+  key: string;
+  type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+  value: string | number | boolean;
 };
 type CompoundFilter = {
-    type: 'and' | 'or';
-    filters: ComparisonFilter[];
+  type: "and" | "or";
+  filters: ComparisonFilter[];
 };
 type AutoRagSearchRequest = {
-    query: string;
-    filters?: CompoundFilter | ComparisonFilter;
-    max_num_results?: number;
-    ranking_options?: {
-        ranker?: string;
-        score_threshold?: number;
-    };
-    rewrite_query?: boolean;
+  query: string;
+  filters?: CompoundFilter | ComparisonFilter;
+  max_num_results?: number;
+  ranking_options?: {
+    ranker?: string;
+    score_threshold?: number;
+  };
+  rewrite_query?: boolean;
 };
 type AutoRagAiSearchRequest = AutoRagSearchRequest & {
-    stream?: boolean;
-    system_prompt?: string;
+  stream?: boolean;
+  system_prompt?: string;
 };
-type AutoRagAiSearchRequestStreaming = Omit<AutoRagAiSearchRequest, 'stream'> & {
-    stream: true;
+type AutoRagAiSearchRequestStreaming = Omit<AutoRagAiSearchRequest, "stream"> & {
+  stream: true;
 };
 type AutoRagSearchResponse = {
-    object: 'vector_store.search_results.page';
-    search_query: string;
-    data: {
-        file_id: string;
-        filename: string;
-        score: number;
-        attributes: Record<string, string | number | boolean | null>;
-        content: {
-            type: 'text';
-            text: string;
-        }[];
+  object: "vector_store.search_results.page";
+  search_query: string;
+  data: {
+    file_id: string;
+    filename: string;
+    score: number;
+    attributes: Record<string, string | number | boolean | null>;
+    content: {
+      type: "text";
+      text: string;
     }[];
-    has_more: boolean;
-    next_page: string | null;
+  }[];
+  has_more: boolean;
+  next_page: string | null;
 };
 type AutoRagListResponse = {
-    id: string;
-    enable: boolean;
-    type: string;
-    source: string;
-    vectorize_name: string;
-    paused: boolean;
-    status: string;
+  id: string;
+  enable: boolean;
+  type: string;
+  source: string;
+  vectorize_name: string;
+  paused: boolean;
+  status: string;
 }[];
 type AutoRagAiSearchResponse = AutoRagSearchResponse & {
-    response: string;
+  response: string;
 };
 declare abstract class AutoRAG {
-    list(): Promise<AutoRagListResponse>;
-    search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
-    aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
-    aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
-    aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse | Response>;
+  list(): Promise<AutoRagListResponse>;
+  search(params: AutoRagSearchRequest): Promise<AutoRagSearchResponse>;
+  aiSearch(params: AutoRagAiSearchRequestStreaming): Promise<Response>;
+  aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse>;
+  aiSearch(params: AutoRagAiSearchRequest): Promise<AutoRagAiSearchResponse | Response>;
 }
 interface BasicImageTransformations {
-    /**
-     * Maximum width in image pixels. The value must be an integer.
-     */
-    width?: number;
-    /**
-     * Maximum height in image pixels. The value must be an integer.
-     */
-    height?: number;
-    /**
-     * Resizing mode as a string. It affects interpretation of width and height
-     * options:
-     *  - scale-down: Similar to contain, but the image is never enlarged. If
-     *    the image is larger than given width or height, it will be resized.
-     *    Otherwise its original size will be kept.
-     *  - contain: Resizes to maximum size that fits within the given width and
-     *    height. If only a single dimension is given (e.g. only width), the
-     *    image will be shrunk or enlarged to exactly match that dimension.
-     *    Aspect ratio is always preserved.
-     *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-     *    and height. If the image has an aspect ratio different from the ratio
-     *    of width and height, it will be cropped to fit.
-     *  - crop: The image will be shrunk and cropped to fit within the area
-     *    specified by width and height. The image will not be enlarged. For images
-     *    smaller than the given dimensions it's the same as scale-down. For
-     *    images larger than the given dimensions, it's the same as cover.
-     *    See also trim.
-     *  - pad: Resizes to the maximum size that fits within the given width and
-     *    height, and then fills the remaining area with a background color
-     *    (white by default). Use of this mode is not recommended, as the same
-     *    effect can be more efficiently achieved with the contain mode and the
-     *    CSS object-fit: contain property.
-     *  - squeeze: Stretches and deforms to the width and height given, even if it
-     *    breaks aspect ratio
-     */
-    fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
-    /**
-     * Image segmentation using artificial intelligence models. Sets pixels not
-     * within selected segment area to transparent e.g "foreground" sets every
-     * background pixel as transparent.
-     */
-    segment?: "foreground";
-    /**
-     * When cropping with fit: "cover", this defines the side or point that should
-     * be left uncropped. The value is either a string
-     * "left", "right", "top", "bottom", "auto", or "center" (the default),
-     * or an object {x, y} containing focal point coordinates in the original
-     * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-     * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-     * crop bottom or left and right sides as necessary, but won’t crop anything
-     * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-     * preserve as much as possible around a point at 20% of the height of the
-     * source image.
-     */
-    gravity?: 'face' | 'left' | 'right' | 'top' | 'bottom' | 'center' | 'auto' | 'entropy' | BasicImageTransformationsGravityCoordinates;
-    /**
-     * Background color to add underneath the image. Applies only to images with
-     * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-     * hsl(…), etc.)
-     */
-    background?: string;
-    /**
-     * Number of degrees (90, 180, 270) to rotate the image by. width and height
-     * options refer to axes after rotation.
-     */
-    rotate?: 0 | 90 | 180 | 270 | 360;
+  /**
+   * Maximum width in image pixels. The value must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height in image pixels. The value must be an integer.
+   */
+  height?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   *  - squeeze: Stretches and deforms to the width and height given, even if it
+   *    breaks aspect ratio
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad" | "squeeze";
+  /**
+   * Image segmentation using artificial intelligence models. Sets pixels not
+   * within selected segment area to transparent e.g "foreground" sets every
+   * background pixel as transparent.
+   */
+  segment?: "foreground";
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?:
+    | "face"
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | "entropy"
+    | BasicImageTransformationsGravityCoordinates;
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
 }
 interface BasicImageTransformationsGravityCoordinates {
-    x?: number;
-    y?: number;
-    mode?: 'remainder' | 'box-center';
+  x?: number;
+  y?: number;
+  mode?: "remainder" | "box-center";
 }
 /**
  * In addition to the properties you can set in the RequestInit dict
@@ -6327,751 +6839,1014 @@ interface BasicImageTransformationsGravityCoordinates {
  * playground.
  */
 interface RequestInitCfProperties extends Record<string, unknown> {
-    cacheEverything?: boolean;
-    /**
-     * A request's cache key is what determines if two requests are
-     * "the same" for caching purposes. If a request has the same cache key
-     * as some previous request, then we can serve the same cached response for
-     * both. (e.g. 'some-key')
-     *
-     * Only available for Enterprise customers.
-     */
-    cacheKey?: string;
-    /**
-     * This allows you to append additional Cache-Tag response headers
-     * to the origin response without modifications to the origin server.
-     * This will allow for greater control over the Purge by Cache Tag feature
-     * utilizing changes only in the Workers process.
-     *
-     * Only available for Enterprise customers.
-     */
-    cacheTags?: string[];
-    /**
-     * Force response to be cached for a given number of seconds. (e.g. 300)
-     */
-    cacheTtl?: number;
-    /**
-     * Force response to be cached for a given number of seconds based on the Origin status code.
-     * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
-     */
-    cacheTtlByStatus?: Record<string, number>;
-    scrapeShield?: boolean;
-    apps?: boolean;
-    image?: RequestInitCfPropertiesImage;
-    minify?: RequestInitCfPropertiesImageMinify;
-    mirage?: boolean;
-    polish?: "lossy" | "lossless" | "off";
-    r2?: RequestInitCfPropertiesR2;
-    /**
-     * Redirects the request to an alternate origin server. You can use this,
-     * for example, to implement load balancing across several origins.
-     * (e.g.us-east.example.com)
-     *
-     * Note - For security reasons, the hostname set in resolveOverride must
-     * be proxied on the same Cloudflare zone of the incoming request.
-     * Otherwise, the setting is ignored. CNAME hosts are allowed, so to
-     * resolve to a host under a different domain or a DNS only domain first
-     * declare a CNAME record within your own zone’s DNS mapping to the
-     * external hostname, set proxy on Cloudflare, then set resolveOverride
-     * to point to that CNAME record.
-     */
-    resolveOverride?: string;
+  cacheEverything?: boolean;
+  /**
+   * A request's cache key is what determines if two requests are
+   * "the same" for caching purposes. If a request has the same cache key
+   * as some previous request, then we can serve the same cached response for
+   * both. (e.g. 'some-key')
+   *
+   * Only available for Enterprise customers.
+   */
+  cacheKey?: string;
+  /**
+   * This allows you to append additional Cache-Tag response headers
+   * to the origin response without modifications to the origin server.
+   * This will allow for greater control over the Purge by Cache Tag feature
+   * utilizing changes only in the Workers process.
+   *
+   * Only available for Enterprise customers.
+   */
+  cacheTags?: string[];
+  /**
+   * Force response to be cached for a given number of seconds. (e.g. 300)
+   */
+  cacheTtl?: number;
+  /**
+   * Force response to be cached for a given number of seconds based on the Origin status code.
+   * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
+   */
+  cacheTtlByStatus?: Record<string, number>;
+  scrapeShield?: boolean;
+  apps?: boolean;
+  image?: RequestInitCfPropertiesImage;
+  minify?: RequestInitCfPropertiesImageMinify;
+  mirage?: boolean;
+  polish?: "lossy" | "lossless" | "off";
+  r2?: RequestInitCfPropertiesR2;
+  /**
+   * Redirects the request to an alternate origin server. You can use this,
+   * for example, to implement load balancing across several origins.
+   * (e.g.us-east.example.com)
+   *
+   * Note - For security reasons, the hostname set in resolveOverride must
+   * be proxied on the same Cloudflare zone of the incoming request.
+   * Otherwise, the setting is ignored. CNAME hosts are allowed, so to
+   * resolve to a host under a different domain or a DNS only domain first
+   * declare a CNAME record within your own zone’s DNS mapping to the
+   * external hostname, set proxy on Cloudflare, then set resolveOverride
+   * to point to that CNAME record.
+   */
+  resolveOverride?: string;
 }
 interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
-    /**
-     * Absolute URL of the image file to use for the drawing. It can be any of
-     * the supported file formats. For drawing of watermarks or non-rectangular
-     * overlays we recommend using PNG or WebP images.
-     */
-    url: string;
-    /**
-     * Floating-point number between 0 (transparent) and 1 (opaque).
-     * For example, opacity: 0.5 makes overlay semitransparent.
-     */
-    opacity?: number;
-    /**
-     * - If set to true, the overlay image will be tiled to cover the entire
-     *   area. This is useful for stock-photo-like watermarks.
-     * - If set to "x", the overlay image will be tiled horizontally only
-     *   (form a line).
-     * - If set to "y", the overlay image will be tiled vertically only
-     *   (form a line).
-     */
-    repeat?: true | "x" | "y";
-    /**
-     * Position of the overlay image relative to a given edge. Each property is
-     * an offset in pixels. 0 aligns exactly to the edge. For example, left: 10
-     * positions left side of the overlay 10 pixels from the left edge of the
-     * image it's drawn over. bottom: 0 aligns bottom of the overlay with bottom
-     * of the background image.
-     *
-     * Setting both left & right, or both top & bottom is an error.
-     *
-     * If no position is specified, the image will be centered.
-     */
-    top?: number;
-    left?: number;
-    bottom?: number;
-    right?: number;
+  /**
+   * Absolute URL of the image file to use for the drawing. It can be any of
+   * the supported file formats. For drawing of watermarks or non-rectangular
+   * overlays we recommend using PNG or WebP images.
+   */
+  url: string;
+  /**
+   * Floating-point number between 0 (transparent) and 1 (opaque).
+   * For example, opacity: 0.5 makes overlay semitransparent.
+   */
+  opacity?: number;
+  /**
+   * - If set to true, the overlay image will be tiled to cover the entire
+   *   area. This is useful for stock-photo-like watermarks.
+   * - If set to "x", the overlay image will be tiled horizontally only
+   *   (form a line).
+   * - If set to "y", the overlay image will be tiled vertically only
+   *   (form a line).
+   */
+  repeat?: true | "x" | "y";
+  /**
+   * Position of the overlay image relative to a given edge. Each property is
+   * an offset in pixels. 0 aligns exactly to the edge. For example, left: 10
+   * positions left side of the overlay 10 pixels from the left edge of the
+   * image it's drawn over. bottom: 0 aligns bottom of the overlay with bottom
+   * of the background image.
+   *
+   * Setting both left & right, or both top & bottom is an error.
+   *
+   * If no position is specified, the image will be centered.
+   */
+  top?: number;
+  left?: number;
+  bottom?: number;
+  right?: number;
 }
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {
-    /**
-     * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
-     * easier to specify higher-DPI sizes in <img srcset>.
-     */
-    dpr?: number;
-    /**
-     * Allows you to trim your image. Takes dpr into account and is performed before
-     * resizing or rotation.
-     *
-     * It can be used as:
-     * - left, top, right, bottom - it will specify the number of pixels to cut
-     *   off each side
-     * - width, height - the width/height you'd like to end up with - can be used
-     *   in combination with the properties above
-     * - border - this will automatically trim the surroundings of an image based on
-     *   it's color. It consists of three properties:
-     *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
-     *    - tolerance: difference from color to treat as color
-     *    - keep: the number of pixels of border to keep
-     */
-    trim?: "border" | {
+  /**
+   * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
+   * easier to specify higher-DPI sizes in <img srcset>.
+   */
+  dpr?: number;
+  /**
+   * Allows you to trim your image. Takes dpr into account and is performed before
+   * resizing or rotation.
+   *
+   * It can be used as:
+   * - left, top, right, bottom - it will specify the number of pixels to cut
+   *   off each side
+   * - width, height - the width/height you'd like to end up with - can be used
+   *   in combination with the properties above
+   * - border - this will automatically trim the surroundings of an image based on
+   *   it's color. It consists of three properties:
+   *    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)
+   *    - tolerance: difference from color to treat as color
+   *    - keep: the number of pixels of border to keep
+   */
+  trim?:
+    | "border"
+    | {
         top?: number;
         bottom?: number;
         left?: number;
         right?: number;
         width?: number;
         height?: number;
-        border?: boolean | {
-            color?: string;
-            tolerance?: number;
-            keep?: number;
-        };
-    };
-    /**
-     * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
-     * make images look worse, but load faster. The default is 85. It applies only
-     * to JPEG and WebP images. It doesn’t have any effect on PNG.
-     */
-    quality?: number | "low" | "medium-low" | "medium-high" | "high";
-    /**
-     * Output format to generate. It can be:
-     *  - avif: generate images in AVIF format.
-     *  - webp: generate images in Google WebP format. Set quality to 100 to get
-     *    the WebP-lossless format.
-     *  - json: instead of generating an image, outputs information about the
-     *    image, in JSON format. The JSON object will contain image size
-     *    (before and after resizing), source image’s MIME type, file size, etc.
-     * - jpeg: generate images in JPEG format.
-     * - png: generate images in PNG format.
-     */
-    format?: "avif" | "webp" | "json" | "jpeg" | "png" | "baseline-jpeg" | "png-force" | "svg";
-    /**
-     * Whether to preserve animation frames from input files. Default is true.
-     * Setting it to false reduces animations to still images. This setting is
-     * recommended when enlarging images or processing arbitrary user content,
-     * because large GIF animations can weigh tens or even hundreds of megabytes.
-     * It is also useful to set anim:false when using format:"json" to get the
-     * response quicker without the number of frames.
-     */
-    anim?: boolean;
-    /**
-     * What EXIF data should be preserved in the output image. Note that EXIF
-     * rotation and embedded color profiles are always applied ("baked in" into
-     * the image), and aren't affected by this option. Note that if the Polish
-     * feature is enabled, all metadata may have been removed already and this
-     * option may have no effect.
-     *  - keep: Preserve most of EXIF metadata, including GPS location if there's
-     *    any.
-     *  - copyright: Only keep the copyright tag, and discard everything else.
-     *    This is the default behavior for JPEG files.
-     *  - none: Discard all invisible EXIF metadata. Currently WebP and PNG
-     *    output formats always discard metadata.
-     */
-    metadata?: "keep" | "copyright" | "none";
-    /**
-     * Strength of sharpening filter to apply to the image. Floating-point
-     * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
-     * recommended value for downscaled images.
-     */
-    sharpen?: number;
-    /**
-     * Radius of a blur filter (approximate gaussian). Maximum supported radius
-     * is 250.
-     */
-    blur?: number;
-    /**
-     * Overlays are drawn in the order they appear in the array (last array
-     * entry is the topmost layer).
-     */
-    draw?: RequestInitCfPropertiesImageDraw[];
-    /**
-     * Fetching image from authenticated origin. Setting this property will
-     * pass authentication headers (Authorization, Cookie, etc.) through to
-     * the origin.
-     */
-    "origin-auth"?: "share-publicly";
-    /**
-     * Adds a border around the image. The border is added after resizing. Border
-     * width takes dpr into account, and can be specified either using a single
-     * width property, or individually for each side.
-     */
-    border?: {
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
+  /**
+   * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
+   * make images look worse, but load faster. The default is 85. It applies only
+   * to JPEG and WebP images. It doesn’t have any effect on PNG.
+   */
+  quality?: number | "low" | "medium-low" | "medium-high" | "high";
+  /**
+   * Output format to generate. It can be:
+   *  - avif: generate images in AVIF format.
+   *  - webp: generate images in Google WebP format. Set quality to 100 to get
+   *    the WebP-lossless format.
+   *  - json: instead of generating an image, outputs information about the
+   *    image, in JSON format. The JSON object will contain image size
+   *    (before and after resizing), source image’s MIME type, file size, etc.
+   * - jpeg: generate images in JPEG format.
+   * - png: generate images in PNG format.
+   */
+  format?: "avif" | "webp" | "json" | "jpeg" | "png" | "baseline-jpeg" | "png-force" | "svg";
+  /**
+   * Whether to preserve animation frames from input files. Default is true.
+   * Setting it to false reduces animations to still images. This setting is
+   * recommended when enlarging images or processing arbitrary user content,
+   * because large GIF animations can weigh tens or even hundreds of megabytes.
+   * It is also useful to set anim:false when using format:"json" to get the
+   * response quicker without the number of frames.
+   */
+  anim?: boolean;
+  /**
+   * What EXIF data should be preserved in the output image. Note that EXIF
+   * rotation and embedded color profiles are always applied ("baked in" into
+   * the image), and aren't affected by this option. Note that if the Polish
+   * feature is enabled, all metadata may have been removed already and this
+   * option may have no effect.
+   *  - keep: Preserve most of EXIF metadata, including GPS location if there's
+   *    any.
+   *  - copyright: Only keep the copyright tag, and discard everything else.
+   *    This is the default behavior for JPEG files.
+   *  - none: Discard all invisible EXIF metadata. Currently WebP and PNG
+   *    output formats always discard metadata.
+   */
+  metadata?: "keep" | "copyright" | "none";
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
+  /**
+   * Overlays are drawn in the order they appear in the array (last array
+   * entry is the topmost layer).
+   */
+  draw?: RequestInitCfPropertiesImageDraw[];
+  /**
+   * Fetching image from authenticated origin. Setting this property will
+   * pass authentication headers (Authorization, Cookie, etc.) through to
+   * the origin.
+   */
+  "origin-auth"?: "share-publicly";
+  /**
+   * Adds a border around the image. The border is added after resizing. Border
+   * width takes dpr into account, and can be specified either using a single
+   * width property, or individually for each side.
+   */
+  border?:
+    | {
         color: string;
         width: number;
-    } | {
+      }
+    | {
         color: string;
         top: number;
         right: number;
         bottom: number;
         left: number;
-    };
-    /**
-     * Increase brightness by a factor. A value of 1.0 equals no change, a value
-     * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
-     * 0 is ignored.
-     */
-    brightness?: number;
-    /**
-     * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-     * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-     * ignored.
-     */
-    contrast?: number;
-    /**
-     * Increase exposure by a factor. A value of 1.0 equals no change, a value of
-     * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
-     */
-    gamma?: number;
-    /**
-     * Increase contrast by a factor. A value of 1.0 equals no change, a value of
-     * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
-     * ignored.
-     */
-    saturation?: number;
-    /**
-     * Flips the images horizontally, vertically, or both. Flipping is applied before
-     * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
-     * horizontally, then rotated by 90 degrees.
-     */
-    flip?: 'h' | 'v' | 'hv';
-    /**
-     * Slightly reduces latency on a cache miss by selecting a
-     * quickest-to-compress file format, at a cost of increased file size and
-     * lower image quality. It will usually override the format option and choose
-     * JPEG over WebP or AVIF. We do not recommend using this option, except in
-     * unusual circumstances like resizing uncacheable dynamically-generated
-     * images.
-     */
-    compression?: "fast";
+      };
+  /**
+   * Increase brightness by a factor. A value of 1.0 equals no change, a value
+   * of 0.5 equals half brightness, and a value of 2.0 equals twice as bright.
+   * 0 is ignored.
+   */
+  brightness?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  contrast?: number;
+  /**
+   * Increase exposure by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 darkens the image, and a value of 2.0 lightens the image. 0 is ignored.
+   */
+  gamma?: number;
+  /**
+   * Increase contrast by a factor. A value of 1.0 equals no change, a value of
+   * 0.5 equals low contrast, and a value of 2.0 equals high contrast. 0 is
+   * ignored.
+   */
+  saturation?: number;
+  /**
+   * Flips the images horizontally, vertically, or both. Flipping is applied before
+   * rotation, so if you apply flip=h,rotate=90 then the image will be flipped
+   * horizontally, then rotated by 90 degrees.
+   */
+  flip?: "h" | "v" | "hv";
+  /**
+   * Slightly reduces latency on a cache miss by selecting a
+   * quickest-to-compress file format, at a cost of increased file size and
+   * lower image quality. It will usually override the format option and choose
+   * JPEG over WebP or AVIF. We do not recommend using this option, except in
+   * unusual circumstances like resizing uncacheable dynamically-generated
+   * images.
+   */
+  compression?: "fast";
 }
 interface RequestInitCfPropertiesImageMinify {
-    javascript?: boolean;
-    css?: boolean;
-    html?: boolean;
+  javascript?: boolean;
+  css?: boolean;
+  html?: boolean;
 }
 interface RequestInitCfPropertiesR2 {
-    /**
-     * Colo id of bucket that an object is stored in
-     */
-    bucketColoId?: number;
+  /**
+   * Colo id of bucket that an object is stored in
+   */
+  bucketColoId?: number;
 }
 /**
  * Request metadata provided by Cloudflare's edge.
  */
-type IncomingRequestCfProperties<HostMetadata = unknown> = IncomingRequestCfPropertiesBase & IncomingRequestCfPropertiesBotManagementEnterprise & IncomingRequestCfPropertiesCloudflareForSaaSEnterprise<HostMetadata> & IncomingRequestCfPropertiesGeographicInformation & IncomingRequestCfPropertiesCloudflareAccessOrApiShield;
+type IncomingRequestCfProperties<HostMetadata = unknown> = IncomingRequestCfPropertiesBase &
+  IncomingRequestCfPropertiesBotManagementEnterprise &
+  IncomingRequestCfPropertiesCloudflareForSaaSEnterprise<HostMetadata> &
+  IncomingRequestCfPropertiesGeographicInformation &
+  IncomingRequestCfPropertiesCloudflareAccessOrApiShield;
 interface IncomingRequestCfPropertiesBase extends Record<string, unknown> {
-    /**
-     * [ASN](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) of the incoming request.
-     *
-     * @example 395747
-     */
-    asn?: number;
-    /**
-     * The organization which owns the ASN of the incoming request.
-     *
-     * @example "Google Cloud"
-     */
-    asOrganization?: string;
-    /**
-     * The original value of the `Accept-Encoding` header if Cloudflare modified it.
-     *
-     * @example "gzip, deflate, br"
-     */
-    clientAcceptEncoding?: string;
-    /**
-     * The number of milliseconds it took for the request to reach your worker.
-     *
-     * @example 22
-     */
-    clientTcpRtt?: number;
-    /**
-     * The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)
-     * airport code of the data center that the request hit.
-     *
-     * @example "DFW"
-     */
-    colo: string;
-    /**
-     * Represents the upstream's response to a
-     * [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)
-     * from cloudflare.
-     *
-     * For workers with no upstream, this will always be `1`.
-     *
-     * @example 3
-     */
-    edgeRequestKeepAliveStatus: IncomingRequestCfPropertiesEdgeRequestKeepAliveStatus;
-    /**
-     * The HTTP Protocol the request used.
-     *
-     * @example "HTTP/2"
-     */
-    httpProtocol: string;
-    /**
-     * The browser-requested prioritization information in the request object.
-     *
-     * If no information was set, defaults to the empty string `""`
-     *
-     * @example "weight=192;exclusive=0;group=3;group-weight=127"
-     * @default ""
-     */
-    requestPriority: string;
-    /**
-     * The TLS version of the connection to Cloudflare.
-     * In requests served over plaintext (without TLS), this property is the empty string `""`.
-     *
-     * @example "TLSv1.3"
-     */
-    tlsVersion: string;
-    /**
-     * The cipher for the connection to Cloudflare.
-     * In requests served over plaintext (without TLS), this property is the empty string `""`.
-     *
-     * @example "AEAD-AES128-GCM-SHA256"
-     */
-    tlsCipher: string;
-    /**
-     * Metadata containing the [`HELLO`](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2) and [`FINISHED`](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9) messages from this request's TLS handshake.
-     *
-     * If the incoming request was served over plaintext (without TLS) this field is undefined.
-     */
-    tlsExportedAuthenticator?: IncomingRequestCfPropertiesExportedAuthenticatorMetadata;
+  /**
+   * [ASN](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) of the incoming request.
+   *
+   * @example 395747
+   */
+  asn?: number;
+  /**
+   * The organization which owns the ASN of the incoming request.
+   *
+   * @example "Google Cloud"
+   */
+  asOrganization?: string;
+  /**
+   * The original value of the `Accept-Encoding` header if Cloudflare modified it.
+   *
+   * @example "gzip, deflate, br"
+   */
+  clientAcceptEncoding?: string;
+  /**
+   * The number of milliseconds it took for the request to reach your worker.
+   *
+   * @example 22
+   */
+  clientTcpRtt?: number;
+  /**
+   * The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)
+   * airport code of the data center that the request hit.
+   *
+   * @example "DFW"
+   */
+  colo: string;
+  /**
+   * Represents the upstream's response to a
+   * [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)
+   * from cloudflare.
+   *
+   * For workers with no upstream, this will always be `1`.
+   *
+   * @example 3
+   */
+  edgeRequestKeepAliveStatus: IncomingRequestCfPropertiesEdgeRequestKeepAliveStatus;
+  /**
+   * The HTTP Protocol the request used.
+   *
+   * @example "HTTP/2"
+   */
+  httpProtocol: string;
+  /**
+   * The browser-requested prioritization information in the request object.
+   *
+   * If no information was set, defaults to the empty string `""`
+   *
+   * @example "weight=192;exclusive=0;group=3;group-weight=127"
+   * @default ""
+   */
+  requestPriority: string;
+  /**
+   * The TLS version of the connection to Cloudflare.
+   * In requests served over plaintext (without TLS), this property is the empty string `""`.
+   *
+   * @example "TLSv1.3"
+   */
+  tlsVersion: string;
+  /**
+   * The cipher for the connection to Cloudflare.
+   * In requests served over plaintext (without TLS), this property is the empty string `""`.
+   *
+   * @example "AEAD-AES128-GCM-SHA256"
+   */
+  tlsCipher: string;
+  /**
+   * Metadata containing the [`HELLO`](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2) and [`FINISHED`](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9) messages from this request's TLS handshake.
+   *
+   * If the incoming request was served over plaintext (without TLS) this field is undefined.
+   */
+  tlsExportedAuthenticator?: IncomingRequestCfPropertiesExportedAuthenticatorMetadata;
 }
 interface IncomingRequestCfPropertiesBotManagementBase {
-    /**
-     * Cloudflare’s [level of certainty](https://developers.cloudflare.com/bots/concepts/bot-score/) that a request comes from a bot,
-     * represented as an integer percentage between `1` (almost certainly a bot) and `99` (almost certainly human).
-     *
-     * @example 54
-     */
-    score: number;
-    /**
-     * A boolean value that is true if the request comes from a good bot, like Google or Bing.
-     * Most customers choose to allow this traffic. For more details, see [Traffic from known bots](https://developers.cloudflare.com/firewall/known-issues-and-faq/#how-does-firewall-rules-handle-traffic-from-known-bots).
-     */
-    verifiedBot: boolean;
-    /**
-     * A boolean value that is true if the request originates from a
-     * Cloudflare-verified proxy service.
-     */
-    corporateProxy: boolean;
-    /**
-     * A boolean value that's true if the request matches [file extensions](https://developers.cloudflare.com/bots/reference/static-resources/) for many types of static resources.
-     */
-    staticResource: boolean;
-    /**
-     * List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
-     */
-    detectionIds: number[];
+  /**
+   * Cloudflare’s [level of certainty](https://developers.cloudflare.com/bots/concepts/bot-score/) that a request comes from a bot,
+   * represented as an integer percentage between `1` (almost certainly a bot) and `99` (almost certainly human).
+   *
+   * @example 54
+   */
+  score: number;
+  /**
+   * A boolean value that is true if the request comes from a good bot, like Google or Bing.
+   * Most customers choose to allow this traffic. For more details, see [Traffic from known bots](https://developers.cloudflare.com/firewall/known-issues-and-faq/#how-does-firewall-rules-handle-traffic-from-known-bots).
+   */
+  verifiedBot: boolean;
+  /**
+   * A boolean value that is true if the request originates from a
+   * Cloudflare-verified proxy service.
+   */
+  corporateProxy: boolean;
+  /**
+   * A boolean value that's true if the request matches [file extensions](https://developers.cloudflare.com/bots/reference/static-resources/) for many types of static resources.
+   */
+  staticResource: boolean;
+  /**
+   * List of IDs that correlate to the Bot Management heuristic detections made on a request (you can have multiple heuristic detections on the same request).
+   */
+  detectionIds: number[];
 }
 interface IncomingRequestCfPropertiesBotManagement {
-    /**
-     * Results of Cloudflare's Bot Management analysis
-     */
-    botManagement: IncomingRequestCfPropertiesBotManagementBase;
-    /**
-     * Duplicate of `botManagement.score`.
-     *
-     * @deprecated
-     */
-    clientTrustScore: number;
+  /**
+   * Results of Cloudflare's Bot Management analysis
+   */
+  botManagement: IncomingRequestCfPropertiesBotManagementBase;
+  /**
+   * Duplicate of `botManagement.score`.
+   *
+   * @deprecated
+   */
+  clientTrustScore: number;
 }
-interface IncomingRequestCfPropertiesBotManagementEnterprise extends IncomingRequestCfPropertiesBotManagement {
+interface IncomingRequestCfPropertiesBotManagementEnterprise
+  extends IncomingRequestCfPropertiesBotManagement {
+  /**
+   * Results of Cloudflare's Bot Management analysis
+   */
+  botManagement: IncomingRequestCfPropertiesBotManagementBase & {
     /**
-     * Results of Cloudflare's Bot Management analysis
+     * A [JA3 Fingerprint](https://developers.cloudflare.com/bots/concepts/ja3-fingerprint/) to help profile specific SSL/TLS clients
+     * across different destination IPs, Ports, and X509 certificates.
      */
-    botManagement: IncomingRequestCfPropertiesBotManagementBase & {
-        /**
-         * A [JA3 Fingerprint](https://developers.cloudflare.com/bots/concepts/ja3-fingerprint/) to help profile specific SSL/TLS clients
-         * across different destination IPs, Ports, and X509 certificates.
-         */
-        ja3Hash: string;
-    };
+    ja3Hash: string;
+  };
 }
 interface IncomingRequestCfPropertiesCloudflareForSaaSEnterprise<HostMetadata> {
-    /**
-     * Custom metadata set per-host in [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/).
-     *
-     * This field is only present if you have Cloudflare for SaaS enabled on your account
-     * and you have followed the [required steps to enable it]((https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/custom-metadata/)).
-     */
-    hostMetadata?: HostMetadata;
+  /**
+   * Custom metadata set per-host in [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/).
+   *
+   * This field is only present if you have Cloudflare for SaaS enabled on your account
+   * and you have followed the [required steps to enable it]((https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/domain-support/custom-metadata/)).
+   */
+  hostMetadata?: HostMetadata;
 }
 interface IncomingRequestCfPropertiesCloudflareAccessOrApiShield {
-    /**
-     * Information about the client certificate presented to Cloudflare.
-     *
-     * This is populated when the incoming request is served over TLS using
-     * either Cloudflare Access or API Shield (mTLS)
-     * and the presented SSL certificate has a valid
-     * [Certificate Serial Number](https://ldapwiki.com/wiki/Certificate%20Serial%20Number)
-     * (i.e., not `null` or `""`).
-     *
-     * Otherwise, a set of placeholder values are used.
-     *
-     * The property `certPresented` will be set to `"1"` when
-     * the object is populated (i.e. the above conditions were met).
-     */
-    tlsClientAuth: IncomingRequestCfPropertiesTLSClientAuth | IncomingRequestCfPropertiesTLSClientAuthPlaceholder;
+  /**
+   * Information about the client certificate presented to Cloudflare.
+   *
+   * This is populated when the incoming request is served over TLS using
+   * either Cloudflare Access or API Shield (mTLS)
+   * and the presented SSL certificate has a valid
+   * [Certificate Serial Number](https://ldapwiki.com/wiki/Certificate%20Serial%20Number)
+   * (i.e., not `null` or `""`).
+   *
+   * Otherwise, a set of placeholder values are used.
+   *
+   * The property `certPresented` will be set to `"1"` when
+   * the object is populated (i.e. the above conditions were met).
+   */
+  tlsClientAuth:
+    | IncomingRequestCfPropertiesTLSClientAuth
+    | IncomingRequestCfPropertiesTLSClientAuthPlaceholder;
 }
 /**
  * Metadata about the request's TLS handshake
  */
 interface IncomingRequestCfPropertiesExportedAuthenticatorMetadata {
-    /**
-     * The client's [`HELLO` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2), encoded in hexadecimal
-     *
-     * @example "44372ba35fa1270921d318f34c12f155dc87b682cf36a790cfaa3ba8737a1b5d"
-     */
-    clientHandshake: string;
-    /**
-     * The server's [`HELLO` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2), encoded in hexadecimal
-     *
-     * @example "44372ba35fa1270921d318f34c12f155dc87b682cf36a790cfaa3ba8737a1b5d"
-     */
-    serverHandshake: string;
-    /**
-     * The client's [`FINISHED` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9), encoded in hexadecimal
-     *
-     * @example "084ee802fe1348f688220e2a6040a05b2199a761f33cf753abb1b006792d3f8b"
-     */
-    clientFinished: string;
-    /**
-     * The server's [`FINISHED` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9), encoded in hexadecimal
-     *
-     * @example "084ee802fe1348f688220e2a6040a05b2199a761f33cf753abb1b006792d3f8b"
-     */
-    serverFinished: string;
+  /**
+   * The client's [`HELLO` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2), encoded in hexadecimal
+   *
+   * @example "44372ba35fa1270921d318f34c12f155dc87b682cf36a790cfaa3ba8737a1b5d"
+   */
+  clientHandshake: string;
+  /**
+   * The server's [`HELLO` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.2), encoded in hexadecimal
+   *
+   * @example "44372ba35fa1270921d318f34c12f155dc87b682cf36a790cfaa3ba8737a1b5d"
+   */
+  serverHandshake: string;
+  /**
+   * The client's [`FINISHED` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9), encoded in hexadecimal
+   *
+   * @example "084ee802fe1348f688220e2a6040a05b2199a761f33cf753abb1b006792d3f8b"
+   */
+  clientFinished: string;
+  /**
+   * The server's [`FINISHED` message](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.9), encoded in hexadecimal
+   *
+   * @example "084ee802fe1348f688220e2a6040a05b2199a761f33cf753abb1b006792d3f8b"
+   */
+  serverFinished: string;
 }
 /**
  * Geographic data about the request's origin.
  */
 interface IncomingRequestCfPropertiesGeographicInformation {
-    /**
-     * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
-     *
-     * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
-     *
-     * If Cloudflare is unable to determine where the request originated this property is omitted.
-     *
-     * The country code `"T1"` is used for requests originating on TOR.
-     *
-     * @example "GB"
-     */
-    country?: Iso3166Alpha2Code | "T1";
-    /**
-     * If present, this property indicates that the request originated in the EU
-     *
-     * @example "1"
-     */
-    isEUCountry?: "1";
-    /**
-     * A two-letter code indicating the continent the request originated from.
-     *
-     * @example "AN"
-     */
-    continent?: ContinentCode;
-    /**
-     * The city the request originated from
-     *
-     * @example "Austin"
-     */
-    city?: string;
-    /**
-     * Postal code of the incoming request
-     *
-     * @example "78701"
-     */
-    postalCode?: string;
-    /**
-     * Latitude of the incoming request
-     *
-     * @example "30.27130"
-     */
-    latitude?: string;
-    /**
-     * Longitude of the incoming request
-     *
-     * @example "-97.74260"
-     */
-    longitude?: string;
-    /**
-     * Timezone of the incoming request
-     *
-     * @example "America/Chicago"
-     */
-    timezone?: string;
-    /**
-     * If known, the ISO 3166-2 name for the first level region associated with
-     * the IP address of the incoming request
-     *
-     * @example "Texas"
-     */
-    region?: string;
-    /**
-     * If known, the ISO 3166-2 code for the first-level region associated with
-     * the IP address of the incoming request
-     *
-     * @example "TX"
-     */
-    regionCode?: string;
-    /**
-     * Metro code (DMA) of the incoming request
-     *
-     * @example "635"
-     */
-    metroCode?: string;
+  /**
+   * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
+   *
+   * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
+   *
+   * If Cloudflare is unable to determine where the request originated this property is omitted.
+   *
+   * The country code `"T1"` is used for requests originating on TOR.
+   *
+   * @example "GB"
+   */
+  country?: Iso3166Alpha2Code | "T1";
+  /**
+   * If present, this property indicates that the request originated in the EU
+   *
+   * @example "1"
+   */
+  isEUCountry?: "1";
+  /**
+   * A two-letter code indicating the continent the request originated from.
+   *
+   * @example "AN"
+   */
+  continent?: ContinentCode;
+  /**
+   * The city the request originated from
+   *
+   * @example "Austin"
+   */
+  city?: string;
+  /**
+   * Postal code of the incoming request
+   *
+   * @example "78701"
+   */
+  postalCode?: string;
+  /**
+   * Latitude of the incoming request
+   *
+   * @example "30.27130"
+   */
+  latitude?: string;
+  /**
+   * Longitude of the incoming request
+   *
+   * @example "-97.74260"
+   */
+  longitude?: string;
+  /**
+   * Timezone of the incoming request
+   *
+   * @example "America/Chicago"
+   */
+  timezone?: string;
+  /**
+   * If known, the ISO 3166-2 name for the first level region associated with
+   * the IP address of the incoming request
+   *
+   * @example "Texas"
+   */
+  region?: string;
+  /**
+   * If known, the ISO 3166-2 code for the first-level region associated with
+   * the IP address of the incoming request
+   *
+   * @example "TX"
+   */
+  regionCode?: string;
+  /**
+   * Metro code (DMA) of the incoming request
+   *
+   * @example "635"
+   */
+  metroCode?: string;
 }
 /** Data about the incoming request's TLS certificate */
 interface IncomingRequestCfPropertiesTLSClientAuth {
-    /** Always `"1"`, indicating that the certificate was presented */
-    certPresented: "1";
-    /**
-     * Result of certificate verification.
-     *
-     * @example "FAILED:self signed certificate"
-     */
-    certVerified: Exclude<CertVerificationStatus, "NONE">;
-    /** The presented certificate's revokation status.
-     *
-     * - A value of `"1"` indicates the certificate has been revoked
-     * - A value of `"0"` indicates the certificate has not been revoked
-     */
-    certRevoked: "1" | "0";
-    /**
-     * The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)
-     *
-     * @example "CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
-     */
-    certIssuerDN: string;
-    /**
-     * The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)
-     *
-     * @example "CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
-     */
-    certSubjectDN: string;
-    /**
-     * The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)
-     *
-     * @example "CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
-     */
-    certIssuerDNRFC2253: string;
-    /**
-     * The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)
-     *
-     * @example "CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
-     */
-    certSubjectDNRFC2253: string;
-    /** The certificate issuer's distinguished name (legacy policies) */
-    certIssuerDNLegacy: string;
-    /** The certificate subject's distinguished name (legacy policies) */
-    certSubjectDNLegacy: string;
-    /**
-     * The certificate's serial number
-     *
-     * @example "00936EACBE07F201DF"
-     */
-    certSerial: string;
-    /**
-     * The certificate issuer's serial number
-     *
-     * @example "2489002934BDFEA34"
-     */
-    certIssuerSerial: string;
-    /**
-     * The certificate's Subject Key Identifier
-     *
-     * @example "BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4"
-     */
-    certSKI: string;
-    /**
-     * The certificate issuer's Subject Key Identifier
-     *
-     * @example "BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4"
-     */
-    certIssuerSKI: string;
-    /**
-     * The certificate's SHA-1 fingerprint
-     *
-     * @example "6b9109f323999e52259cda7373ff0b4d26bd232e"
-     */
-    certFingerprintSHA1: string;
-    /**
-     * The certificate's SHA-256 fingerprint
-     *
-     * @example "acf77cf37b4156a2708e34c4eb755f9b5dbbe5ebb55adfec8f11493438d19e6ad3f157f81fa3b98278453d5652b0c1fd1d71e5695ae4d709803a4d3f39de9dea"
-     */
-    certFingerprintSHA256: string;
-    /**
-     * The effective starting date of the certificate
-     *
-     * @example "Dec 22 19:39:00 2018 GMT"
-     */
-    certNotBefore: string;
-    /**
-     * The effective expiration date of the certificate
-     *
-     * @example "Dec 22 19:39:00 2018 GMT"
-     */
-    certNotAfter: string;
+  /** Always `"1"`, indicating that the certificate was presented */
+  certPresented: "1";
+  /**
+   * Result of certificate verification.
+   *
+   * @example "FAILED:self signed certificate"
+   */
+  certVerified: Exclude<CertVerificationStatus, "NONE">;
+  /** The presented certificate's revokation status.
+   *
+   * - A value of `"1"` indicates the certificate has been revoked
+   * - A value of `"0"` indicates the certificate has not been revoked
+   */
+  certRevoked: "1" | "0";
+  /**
+   * The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)
+   *
+   * @example "CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certIssuerDN: string;
+  /**
+   * The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)
+   *
+   * @example "CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certSubjectDN: string;
+  /**
+   * The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)
+   *
+   * @example "CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certIssuerDNRFC2253: string;
+  /**
+   * The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)
+   *
+   * @example "CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare"
+   */
+  certSubjectDNRFC2253: string;
+  /** The certificate issuer's distinguished name (legacy policies) */
+  certIssuerDNLegacy: string;
+  /** The certificate subject's distinguished name (legacy policies) */
+  certSubjectDNLegacy: string;
+  /**
+   * The certificate's serial number
+   *
+   * @example "00936EACBE07F201DF"
+   */
+  certSerial: string;
+  /**
+   * The certificate issuer's serial number
+   *
+   * @example "2489002934BDFEA34"
+   */
+  certIssuerSerial: string;
+  /**
+   * The certificate's Subject Key Identifier
+   *
+   * @example "BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4"
+   */
+  certSKI: string;
+  /**
+   * The certificate issuer's Subject Key Identifier
+   *
+   * @example "BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4"
+   */
+  certIssuerSKI: string;
+  /**
+   * The certificate's SHA-1 fingerprint
+   *
+   * @example "6b9109f323999e52259cda7373ff0b4d26bd232e"
+   */
+  certFingerprintSHA1: string;
+  /**
+   * The certificate's SHA-256 fingerprint
+   *
+   * @example "acf77cf37b4156a2708e34c4eb755f9b5dbbe5ebb55adfec8f11493438d19e6ad3f157f81fa3b98278453d5652b0c1fd1d71e5695ae4d709803a4d3f39de9dea"
+   */
+  certFingerprintSHA256: string;
+  /**
+   * The effective starting date of the certificate
+   *
+   * @example "Dec 22 19:39:00 2018 GMT"
+   */
+  certNotBefore: string;
+  /**
+   * The effective expiration date of the certificate
+   *
+   * @example "Dec 22 19:39:00 2018 GMT"
+   */
+  certNotAfter: string;
 }
 /** Placeholder values for TLS Client Authorization */
 interface IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
-    certPresented: "0";
-    certVerified: "NONE";
-    certRevoked: "0";
-    certIssuerDN: "";
-    certSubjectDN: "";
-    certIssuerDNRFC2253: "";
-    certSubjectDNRFC2253: "";
-    certIssuerDNLegacy: "";
-    certSubjectDNLegacy: "";
-    certSerial: "";
-    certIssuerSerial: "";
-    certSKI: "";
-    certIssuerSKI: "";
-    certFingerprintSHA1: "";
-    certFingerprintSHA256: "";
-    certNotBefore: "";
-    certNotAfter: "";
+  certPresented: "0";
+  certVerified: "NONE";
+  certRevoked: "0";
+  certIssuerDN: "";
+  certSubjectDN: "";
+  certIssuerDNRFC2253: "";
+  certSubjectDNRFC2253: "";
+  certIssuerDNLegacy: "";
+  certSubjectDNLegacy: "";
+  certSerial: "";
+  certIssuerSerial: "";
+  certSKI: "";
+  certIssuerSKI: "";
+  certFingerprintSHA1: "";
+  certFingerprintSHA256: "";
+  certNotBefore: "";
+  certNotAfter: "";
 }
 /** Possible outcomes of TLS verification */
-declare type CertVerificationStatus = 
-/** Authentication succeeded */
-"SUCCESS"
-/** No certificate was presented */
- | "NONE"
-/** Failed because the certificate was self-signed */
- | "FAILED:self signed certificate"
-/** Failed because the certificate failed a trust chain check */
- | "FAILED:unable to verify the first certificate"
-/** Failed because the certificate not yet valid */
- | "FAILED:certificate is not yet valid"
-/** Failed because the certificate is expired */
- | "FAILED:certificate has expired"
-/** Failed for another unspecified reason */
- | "FAILED";
+declare type CertVerificationStatus =
+  /** Authentication succeeded */
+  | "SUCCESS"
+  /** No certificate was presented */
+  | "NONE"
+  /** Failed because the certificate was self-signed */
+  | "FAILED:self signed certificate"
+  /** Failed because the certificate failed a trust chain check */
+  | "FAILED:unable to verify the first certificate"
+  /** Failed because the certificate not yet valid */
+  | "FAILED:certificate is not yet valid"
+  /** Failed because the certificate is expired */
+  | "FAILED:certificate has expired"
+  /** Failed for another unspecified reason */
+  | "FAILED";
 /**
  * An upstream endpoint's response to a TCP `keepalive` message from Cloudflare.
  */
-declare type IncomingRequestCfPropertiesEdgeRequestKeepAliveStatus = 0 /** Unknown */ | 1 /** no keepalives (not found) */ | 2 /** no connection re-use, opening keepalive connection failed */ | 3 /** no connection re-use, keepalive accepted and saved */ | 4 /** connection re-use, refused by the origin server (`TCP FIN`) */ | 5; /** connection re-use, accepted by the origin server */
+declare type IncomingRequestCfPropertiesEdgeRequestKeepAliveStatus =
+  | 0 /** Unknown */
+  | 1 /** no keepalives (not found) */
+  | 2 /** no connection re-use, opening keepalive connection failed */
+  | 3 /** no connection re-use, keepalive accepted and saved */
+  | 4 /** connection re-use, refused by the origin server (`TCP FIN`) */
+  | 5; /** connection re-use, accepted by the origin server */
 /** ISO 3166-1 Alpha-2 codes */
-declare type Iso3166Alpha2Code = "AD" | "AE" | "AF" | "AG" | "AI" | "AL" | "AM" | "AO" | "AQ" | "AR" | "AS" | "AT" | "AU" | "AW" | "AX" | "AZ" | "BA" | "BB" | "BD" | "BE" | "BF" | "BG" | "BH" | "BI" | "BJ" | "BL" | "BM" | "BN" | "BO" | "BQ" | "BR" | "BS" | "BT" | "BV" | "BW" | "BY" | "BZ" | "CA" | "CC" | "CD" | "CF" | "CG" | "CH" | "CI" | "CK" | "CL" | "CM" | "CN" | "CO" | "CR" | "CU" | "CV" | "CW" | "CX" | "CY" | "CZ" | "DE" | "DJ" | "DK" | "DM" | "DO" | "DZ" | "EC" | "EE" | "EG" | "EH" | "ER" | "ES" | "ET" | "FI" | "FJ" | "FK" | "FM" | "FO" | "FR" | "GA" | "GB" | "GD" | "GE" | "GF" | "GG" | "GH" | "GI" | "GL" | "GM" | "GN" | "GP" | "GQ" | "GR" | "GS" | "GT" | "GU" | "GW" | "GY" | "HK" | "HM" | "HN" | "HR" | "HT" | "HU" | "ID" | "IE" | "IL" | "IM" | "IN" | "IO" | "IQ" | "IR" | "IS" | "IT" | "JE" | "JM" | "JO" | "JP" | "KE" | "KG" | "KH" | "KI" | "KM" | "KN" | "KP" | "KR" | "KW" | "KY" | "KZ" | "LA" | "LB" | "LC" | "LI" | "LK" | "LR" | "LS" | "LT" | "LU" | "LV" | "LY" | "MA" | "MC" | "MD" | "ME" | "MF" | "MG" | "MH" | "MK" | "ML" | "MM" | "MN" | "MO" | "MP" | "MQ" | "MR" | "MS" | "MT" | "MU" | "MV" | "MW" | "MX" | "MY" | "MZ" | "NA" | "NC" | "NE" | "NF" | "NG" | "NI" | "NL" | "NO" | "NP" | "NR" | "NU" | "NZ" | "OM" | "PA" | "PE" | "PF" | "PG" | "PH" | "PK" | "PL" | "PM" | "PN" | "PR" | "PS" | "PT" | "PW" | "PY" | "QA" | "RE" | "RO" | "RS" | "RU" | "RW" | "SA" | "SB" | "SC" | "SD" | "SE" | "SG" | "SH" | "SI" | "SJ" | "SK" | "SL" | "SM" | "SN" | "SO" | "SR" | "SS" | "ST" | "SV" | "SX" | "SY" | "SZ" | "TC" | "TD" | "TF" | "TG" | "TH" | "TJ" | "TK" | "TL" | "TM" | "TN" | "TO" | "TR" | "TT" | "TV" | "TW" | "TZ" | "UA" | "UG" | "UM" | "US" | "UY" | "UZ" | "VA" | "VC" | "VE" | "VG" | "VI" | "VN" | "VU" | "WF" | "WS" | "YE" | "YT" | "ZA" | "ZM" | "ZW";
+declare type Iso3166Alpha2Code =
+  | "AD"
+  | "AE"
+  | "AF"
+  | "AG"
+  | "AI"
+  | "AL"
+  | "AM"
+  | "AO"
+  | "AQ"
+  | "AR"
+  | "AS"
+  | "AT"
+  | "AU"
+  | "AW"
+  | "AX"
+  | "AZ"
+  | "BA"
+  | "BB"
+  | "BD"
+  | "BE"
+  | "BF"
+  | "BG"
+  | "BH"
+  | "BI"
+  | "BJ"
+  | "BL"
+  | "BM"
+  | "BN"
+  | "BO"
+  | "BQ"
+  | "BR"
+  | "BS"
+  | "BT"
+  | "BV"
+  | "BW"
+  | "BY"
+  | "BZ"
+  | "CA"
+  | "CC"
+  | "CD"
+  | "CF"
+  | "CG"
+  | "CH"
+  | "CI"
+  | "CK"
+  | "CL"
+  | "CM"
+  | "CN"
+  | "CO"
+  | "CR"
+  | "CU"
+  | "CV"
+  | "CW"
+  | "CX"
+  | "CY"
+  | "CZ"
+  | "DE"
+  | "DJ"
+  | "DK"
+  | "DM"
+  | "DO"
+  | "DZ"
+  | "EC"
+  | "EE"
+  | "EG"
+  | "EH"
+  | "ER"
+  | "ES"
+  | "ET"
+  | "FI"
+  | "FJ"
+  | "FK"
+  | "FM"
+  | "FO"
+  | "FR"
+  | "GA"
+  | "GB"
+  | "GD"
+  | "GE"
+  | "GF"
+  | "GG"
+  | "GH"
+  | "GI"
+  | "GL"
+  | "GM"
+  | "GN"
+  | "GP"
+  | "GQ"
+  | "GR"
+  | "GS"
+  | "GT"
+  | "GU"
+  | "GW"
+  | "GY"
+  | "HK"
+  | "HM"
+  | "HN"
+  | "HR"
+  | "HT"
+  | "HU"
+  | "ID"
+  | "IE"
+  | "IL"
+  | "IM"
+  | "IN"
+  | "IO"
+  | "IQ"
+  | "IR"
+  | "IS"
+  | "IT"
+  | "JE"
+  | "JM"
+  | "JO"
+  | "JP"
+  | "KE"
+  | "KG"
+  | "KH"
+  | "KI"
+  | "KM"
+  | "KN"
+  | "KP"
+  | "KR"
+  | "KW"
+  | "KY"
+  | "KZ"
+  | "LA"
+  | "LB"
+  | "LC"
+  | "LI"
+  | "LK"
+  | "LR"
+  | "LS"
+  | "LT"
+  | "LU"
+  | "LV"
+  | "LY"
+  | "MA"
+  | "MC"
+  | "MD"
+  | "ME"
+  | "MF"
+  | "MG"
+  | "MH"
+  | "MK"
+  | "ML"
+  | "MM"
+  | "MN"
+  | "MO"
+  | "MP"
+  | "MQ"
+  | "MR"
+  | "MS"
+  | "MT"
+  | "MU"
+  | "MV"
+  | "MW"
+  | "MX"
+  | "MY"
+  | "MZ"
+  | "NA"
+  | "NC"
+  | "NE"
+  | "NF"
+  | "NG"
+  | "NI"
+  | "NL"
+  | "NO"
+  | "NP"
+  | "NR"
+  | "NU"
+  | "NZ"
+  | "OM"
+  | "PA"
+  | "PE"
+  | "PF"
+  | "PG"
+  | "PH"
+  | "PK"
+  | "PL"
+  | "PM"
+  | "PN"
+  | "PR"
+  | "PS"
+  | "PT"
+  | "PW"
+  | "PY"
+  | "QA"
+  | "RE"
+  | "RO"
+  | "RS"
+  | "RU"
+  | "RW"
+  | "SA"
+  | "SB"
+  | "SC"
+  | "SD"
+  | "SE"
+  | "SG"
+  | "SH"
+  | "SI"
+  | "SJ"
+  | "SK"
+  | "SL"
+  | "SM"
+  | "SN"
+  | "SO"
+  | "SR"
+  | "SS"
+  | "ST"
+  | "SV"
+  | "SX"
+  | "SY"
+  | "SZ"
+  | "TC"
+  | "TD"
+  | "TF"
+  | "TG"
+  | "TH"
+  | "TJ"
+  | "TK"
+  | "TL"
+  | "TM"
+  | "TN"
+  | "TO"
+  | "TR"
+  | "TT"
+  | "TV"
+  | "TW"
+  | "TZ"
+  | "UA"
+  | "UG"
+  | "UM"
+  | "US"
+  | "UY"
+  | "UZ"
+  | "VA"
+  | "VC"
+  | "VE"
+  | "VG"
+  | "VI"
+  | "VN"
+  | "VU"
+  | "WF"
+  | "WS"
+  | "YE"
+  | "YT"
+  | "ZA"
+  | "ZM"
+  | "ZW";
 /** The 2-letter continent codes Cloudflare uses */
 declare type ContinentCode = "AF" | "AN" | "AS" | "EU" | "NA" | "OC" | "SA";
-type CfProperties<HostMetadata = unknown> = IncomingRequestCfProperties<HostMetadata> | RequestInitCfProperties;
+type CfProperties<HostMetadata = unknown> =
+  | IncomingRequestCfProperties<HostMetadata>
+  | RequestInitCfProperties;
 interface D1Meta {
-    duration: number;
-    size_after: number;
-    rows_read: number;
-    rows_written: number;
-    last_row_id: number;
-    changed_db: boolean;
-    changes: number;
+  duration: number;
+  size_after: number;
+  rows_read: number;
+  rows_written: number;
+  last_row_id: number;
+  changed_db: boolean;
+  changes: number;
+  /**
+   * The region of the database instance that executed the query.
+   */
+  served_by_region?: string;
+  /**
+   * True if-and-only-if the database instance that executed the query was the primary.
+   */
+  served_by_primary?: boolean;
+  timings?: {
     /**
-     * The region of the database instance that executed the query.
+     * The duration of the SQL query execution by the database instance. It doesn't include any network time.
      */
-    served_by_region?: string;
-    /**
-     * True if-and-only-if the database instance that executed the query was the primary.
-     */
-    served_by_primary?: boolean;
-    timings?: {
-        /**
-         * The duration of the SQL query execution by the database instance. It doesn't include any network time.
-         */
-        sql_duration_ms: number;
-    };
-    /**
-     * Number of total attempts to execute the query, due to automatic retries.
-     * Note: All other fields in the response like `timings` only apply to the last attempt.
-     */
-    total_attempts?: number;
+    sql_duration_ms: number;
+  };
+  /**
+   * Number of total attempts to execute the query, due to automatic retries.
+   * Note: All other fields in the response like `timings` only apply to the last attempt.
+   */
+  total_attempts?: number;
 }
 interface D1Response {
-    success: true;
-    meta: D1Meta & Record<string, unknown>;
-    error?: never;
+  success: true;
+  meta: D1Meta & Record<string, unknown>;
+  error?: never;
 }
 type D1Result<T = unknown> = D1Response & {
-    results: T[];
+  results: T[];
 };
 interface D1ExecResult {
-    count: number;
-    duration: number;
+  count: number;
+  duration: number;
 }
-type D1SessionConstraint = 
-// Indicates that the first query should go to the primary, and the rest queries
-// using the same D1DatabaseSession will go to any replica that is consistent with
-// the bookmark maintained by the session (returned by the first query).
-'first-primary'
-// Indicates that the first query can go anywhere (primary or replica), and the rest queries
-// using the same D1DatabaseSession will go to any replica that is consistent with
-// the bookmark maintained by the session (returned by the first query).
- | 'first-unconstrained';
+type D1SessionConstraint =
+  // Indicates that the first query should go to the primary, and the rest queries
+  // using the same D1DatabaseSession will go to any replica that is consistent with
+  // the bookmark maintained by the session (returned by the first query).
+  | "first-primary"
+  // Indicates that the first query can go anywhere (primary or replica), and the rest queries
+  // using the same D1DatabaseSession will go to any replica that is consistent with
+  // the bookmark maintained by the session (returned by the first query).
+  | "first-unconstrained";
 type D1SessionBookmark = string;
 declare abstract class D1Database {
-    prepare(query: string): D1PreparedStatement;
-    batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
-    exec(query: string): Promise<D1ExecResult>;
-    /**
-     * Creates a new D1 Session anchored at the given constraint or the bookmark.
-     * All queries executed using the created session will have sequential consistency,
-     * meaning that all writes done through the session will be visible in subsequent reads.
-     *
-     * @param constraintOrBookmark Either the session constraint or the explicit bookmark to anchor the created session.
-     */
-    withSession(constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint): D1DatabaseSession;
-    /**
-     * @deprecated dump() will be removed soon, only applies to deprecated alpha v1 databases.
-     */
-    dump(): Promise<ArrayBuffer>;
+  prepare(query: string): D1PreparedStatement;
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+  exec(query: string): Promise<D1ExecResult>;
+  /**
+   * Creates a new D1 Session anchored at the given constraint or the bookmark.
+   * All queries executed using the created session will have sequential consistency,
+   * meaning that all writes done through the session will be visible in subsequent reads.
+   *
+   * @param constraintOrBookmark Either the session constraint or the explicit bookmark to anchor the created session.
+   */
+  withSession(constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint): D1DatabaseSession;
+  /**
+   * @deprecated dump() will be removed soon, only applies to deprecated alpha v1 databases.
+   */
+  dump(): Promise<ArrayBuffer>;
 }
 declare abstract class D1DatabaseSession {
-    prepare(query: string): D1PreparedStatement;
-    batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
-    /**
-     * @returns The latest session bookmark across all executed queries on the session.
-     *          If no query has been executed yet, `null` is returned.
-     */
-    getBookmark(): D1SessionBookmark | null;
+  prepare(query: string): D1PreparedStatement;
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+  /**
+   * @returns The latest session bookmark across all executed queries on the session.
+   *          If no query has been executed yet, `null` is returned.
+   */
+  getBookmark(): D1SessionBookmark | null;
 }
 declare abstract class D1PreparedStatement {
-    bind(...values: unknown[]): D1PreparedStatement;
-    first<T = unknown>(colName: string): Promise<T | null>;
-    first<T = Record<string, unknown>>(): Promise<T | null>;
-    run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
-    all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
-    raw<T = unknown[]>(options: {
-        columnNames: true;
-    }): Promise<[
-        string[],
-        ...T[]
-    ]>;
-    raw<T = unknown[]>(options?: {
-        columnNames?: false;
-    }): Promise<T[]>;
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(colName: string): Promise<T | null>;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+  all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+  raw<T = unknown[]>(options: { columnNames: true }): Promise<[string[], ...T[]]>;
+  raw<T = unknown[]>(options?: { columnNames?: false }): Promise<T[]>;
 }
 // `Disposable` was added to TypeScript's standard lib types in version 5.2.
 // To support older TypeScript versions, define an empty `Disposable` interface.
@@ -7079,894 +7854,1027 @@ declare abstract class D1PreparedStatement {
 // but this will ensure type checking on older versions still passes.
 // TypeScript's interface merging will ensure our empty interface is effectively
 // ignored when `Disposable` is included in the standard lib.
-interface Disposable {
-}
+interface Disposable {}
 /**
  * An email message that can be sent from a Worker.
  */
 interface EmailMessage {
-    /**
-     * Envelope From attribute of the email message.
-     */
-    readonly from: string;
-    /**
-     * Envelope To attribute of the email message.
-     */
-    readonly to: string;
+  /**
+   * Envelope From attribute of the email message.
+   */
+  readonly from: string;
+  /**
+   * Envelope To attribute of the email message.
+   */
+  readonly to: string;
 }
 /**
  * An email message that is sent to a consumer Worker and can be rejected/forwarded.
  */
 interface ForwardableEmailMessage extends EmailMessage {
-    /**
-     * Stream of the email message content.
-     */
-    readonly raw: ReadableStream<Uint8Array>;
-    /**
-     * An [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
-     */
-    readonly headers: Headers;
-    /**
-     * Size of the email message content.
-     */
-    readonly rawSize: number;
-    /**
-     * Reject this email message by returning a permanent SMTP error back to the connecting client including the given reason.
-     * @param reason The reject reason.
-     * @returns void
-     */
-    setReject(reason: string): void;
-    /**
-     * Forward this email message to a verified destination address of the account.
-     * @param rcptTo Verified destination address.
-     * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
-     * @returns A promise that resolves when the email message is forwarded.
-     */
-    forward(rcptTo: string, headers?: Headers): Promise<void>;
-    /**
-     * Reply to the sender of this email message with a new EmailMessage object.
-     * @param message The reply message.
-     * @returns A promise that resolves when the email message is replied.
-     */
-    reply(message: EmailMessage): Promise<void>;
+  /**
+   * Stream of the email message content.
+   */
+  readonly raw: ReadableStream<Uint8Array>;
+  /**
+   * An [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
+   */
+  readonly headers: Headers;
+  /**
+   * Size of the email message content.
+   */
+  readonly rawSize: number;
+  /**
+   * Reject this email message by returning a permanent SMTP error back to the connecting client including the given reason.
+   * @param reason The reject reason.
+   * @returns void
+   */
+  setReject(reason: string): void;
+  /**
+   * Forward this email message to a verified destination address of the account.
+   * @param rcptTo Verified destination address.
+   * @param headers A [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
+   * @returns A promise that resolves when the email message is forwarded.
+   */
+  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  /**
+   * Reply to the sender of this email message with a new EmailMessage object.
+   * @param message The reply message.
+   * @returns A promise that resolves when the email message is replied.
+   */
+  reply(message: EmailMessage): Promise<void>;
 }
 /**
  * A binding that allows a Worker to send email messages.
  */
 interface SendEmail {
-    send(message: EmailMessage): Promise<void>;
+  send(message: EmailMessage): Promise<void>;
 }
 declare abstract class EmailEvent extends ExtendableEvent {
-    readonly message: ForwardableEmailMessage;
+  readonly message: ForwardableEmailMessage;
 }
-declare type EmailExportedHandler<Env = unknown> = (message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext) => void | Promise<void>;
+declare type EmailExportedHandler<Env = unknown> = (
+  message: ForwardableEmailMessage,
+  env: Env,
+  ctx: ExecutionContext,
+) => void | Promise<void>;
 declare module "cloudflare:email" {
-    let _EmailMessage: {
-        prototype: EmailMessage;
-        new (from: string, to: string, raw: ReadableStream | string): EmailMessage;
-    };
-    export { _EmailMessage as EmailMessage };
+  let _EmailMessage: {
+    prototype: EmailMessage;
+    new (from: string, to: string, raw: ReadableStream | string): EmailMessage;
+  };
+  export { _EmailMessage as EmailMessage };
 }
 /**
  * Hello World binding to serve as an explanatory example. DO NOT USE
  */
 interface HelloWorldBinding {
-    /**
-     * Retrieve the current stored value
-     */
-    get(): Promise<{
-        value: string;
-        ms?: number;
-    }>;
-    /**
-     * Set a new stored value
-     */
-    set(value: string): Promise<void>;
+  /**
+   * Retrieve the current stored value
+   */
+  get(): Promise<{
+    value: string;
+    ms?: number;
+  }>;
+  /**
+   * Set a new stored value
+   */
+  set(value: string): Promise<void>;
 }
 interface Hyperdrive {
-    /**
-     * Connect directly to Hyperdrive as if it's your database, returning a TCP socket.
-     *
-     * Calling this method returns an idential socket to if you call
-     * `connect("host:port")` using the `host` and `port` fields from this object.
-     * Pick whichever approach works better with your preferred DB client library.
-     *
-     * Note that this socket is not yet authenticated -- it's expected that your
-     * code (or preferably, the client library of your choice) will authenticate
-     * using the information in this class's readonly fields.
-     */
-    connect(): Socket;
-    /**
-     * A valid DB connection string that can be passed straight into the typical
-     * client library/driver/ORM. This will typically be the easiest way to use
-     * Hyperdrive.
-     */
-    readonly connectionString: string;
-    /*
-     * A randomly generated hostname that is only valid within the context of the
-     * currently running Worker which, when passed into `connect()` function from
-     * the "cloudflare:sockets" module, will connect to the Hyperdrive instance
-     * for your database.
-     */
-    readonly host: string;
-    /*
-     * The port that must be paired the the host field when connecting.
-     */
-    readonly port: number;
-    /*
-     * The username to use when authenticating to your database via Hyperdrive.
-     * Unlike the host and password, this will be the same every time
-     */
-    readonly user: string;
-    /*
-     * The randomly generated password to use when authenticating to your
-     * database via Hyperdrive. Like the host field, this password is only valid
-     * within the context of the currently running Worker instance from which
-     * it's read.
-     */
-    readonly password: string;
-    /*
-     * The name of the database to connect to.
-     */
-    readonly database: string;
+  /**
+   * Connect directly to Hyperdrive as if it's your database, returning a TCP socket.
+   *
+   * Calling this method returns an idential socket to if you call
+   * `connect("host:port")` using the `host` and `port` fields from this object.
+   * Pick whichever approach works better with your preferred DB client library.
+   *
+   * Note that this socket is not yet authenticated -- it's expected that your
+   * code (or preferably, the client library of your choice) will authenticate
+   * using the information in this class's readonly fields.
+   */
+  connect(): Socket;
+  /**
+   * A valid DB connection string that can be passed straight into the typical
+   * client library/driver/ORM. This will typically be the easiest way to use
+   * Hyperdrive.
+   */
+  readonly connectionString: string;
+  /*
+   * A randomly generated hostname that is only valid within the context of the
+   * currently running Worker which, when passed into `connect()` function from
+   * the "cloudflare:sockets" module, will connect to the Hyperdrive instance
+   * for your database.
+   */
+  readonly host: string;
+  /*
+   * The port that must be paired the the host field when connecting.
+   */
+  readonly port: number;
+  /*
+   * The username to use when authenticating to your database via Hyperdrive.
+   * Unlike the host and password, this will be the same every time
+   */
+  readonly user: string;
+  /*
+   * The randomly generated password to use when authenticating to your
+   * database via Hyperdrive. Like the host field, this password is only valid
+   * within the context of the currently running Worker instance from which
+   * it's read.
+   */
+  readonly password: string;
+  /*
+   * The name of the database to connect to.
+   */
+  readonly database: string;
 }
 // Copyright (c) 2024 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
-type ImageInfoResponse = {
-    format: 'image/svg+xml';
-} | {
-    format: string;
-    fileSize: number;
-    width: number;
-    height: number;
-};
+type ImageInfoResponse =
+  | {
+      format: "image/svg+xml";
+    }
+  | {
+      format: string;
+      fileSize: number;
+      width: number;
+      height: number;
+    };
 type ImageTransform = {
-    width?: number;
-    height?: number;
-    background?: string;
-    blur?: number;
-    border?: {
+  width?: number;
+  height?: number;
+  background?: string;
+  blur?: number;
+  border?:
+    | {
         color?: string;
         width?: number;
-    } | {
+      }
+    | {
         top?: number;
         bottom?: number;
         left?: number;
         right?: number;
-    };
-    brightness?: number;
-    contrast?: number;
-    fit?: 'scale-down' | 'contain' | 'pad' | 'squeeze' | 'cover' | 'crop';
-    flip?: 'h' | 'v' | 'hv';
-    gamma?: number;
-    segment?: 'foreground';
-    gravity?: 'face' | 'left' | 'right' | 'top' | 'bottom' | 'center' | 'auto' | 'entropy' | {
+      };
+  brightness?: number;
+  contrast?: number;
+  fit?: "scale-down" | "contain" | "pad" | "squeeze" | "cover" | "crop";
+  flip?: "h" | "v" | "hv";
+  gamma?: number;
+  segment?: "foreground";
+  gravity?:
+    | "face"
+    | "left"
+    | "right"
+    | "top"
+    | "bottom"
+    | "center"
+    | "auto"
+    | "entropy"
+    | {
         x?: number;
         y?: number;
-        mode: 'remainder' | 'box-center';
-    };
-    rotate?: 0 | 90 | 180 | 270;
-    saturation?: number;
-    sharpen?: number;
-    trim?: 'border' | {
+        mode: "remainder" | "box-center";
+      };
+  rotate?: 0 | 90 | 180 | 270;
+  saturation?: number;
+  sharpen?: number;
+  trim?:
+    | "border"
+    | {
         top?: number;
         bottom?: number;
         left?: number;
         right?: number;
         width?: number;
         height?: number;
-        border?: boolean | {
-            color?: string;
-            tolerance?: number;
-            keep?: number;
-        };
-    };
+        border?:
+          | boolean
+          | {
+              color?: string;
+              tolerance?: number;
+              keep?: number;
+            };
+      };
 };
 type ImageDrawOptions = {
-    opacity?: number;
-    repeat?: boolean | string;
-    top?: number;
-    left?: number;
-    bottom?: number;
-    right?: number;
+  opacity?: number;
+  repeat?: boolean | string;
+  top?: number;
+  left?: number;
+  bottom?: number;
+  right?: number;
 };
 type ImageInputOptions = {
-    encoding?: 'base64';
+  encoding?: "base64";
 };
 type ImageOutputOptions = {
-    format: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp' | 'image/avif' | 'rgb' | 'rgba';
-    quality?: number;
-    background?: string;
-    anim?: boolean;
+  format: "image/jpeg" | "image/png" | "image/gif" | "image/webp" | "image/avif" | "rgb" | "rgba";
+  quality?: number;
+  background?: string;
+  anim?: boolean;
 };
 interface ImagesBinding {
-    /**
-     * Get image metadata (type, width and height)
-     * @throws {@link ImagesError} with code 9412 if input is not an image
-     * @param stream The image bytes
-     */
-    info(stream: ReadableStream<Uint8Array>, options?: ImageInputOptions): Promise<ImageInfoResponse>;
-    /**
-     * Begin applying a series of transformations to an image
-     * @param stream The image bytes
-     * @returns A transform handle
-     */
-    input(stream: ReadableStream<Uint8Array>, options?: ImageInputOptions): ImageTransformer;
+  /**
+   * Get image metadata (type, width and height)
+   * @throws {@link ImagesError} with code 9412 if input is not an image
+   * @param stream The image bytes
+   */
+  info(stream: ReadableStream<Uint8Array>, options?: ImageInputOptions): Promise<ImageInfoResponse>;
+  /**
+   * Begin applying a series of transformations to an image
+   * @param stream The image bytes
+   * @returns A transform handle
+   */
+  input(stream: ReadableStream<Uint8Array>, options?: ImageInputOptions): ImageTransformer;
 }
 interface ImageTransformer {
-    /**
-     * Apply transform next, returning a transform handle.
-     * You can then apply more transformations, draw, or retrieve the output.
-     * @param transform
-     */
-    transform(transform: ImageTransform): ImageTransformer;
-    /**
-     * Draw an image on this transformer, returning a transform handle.
-     * You can then apply more transformations, draw, or retrieve the output.
-     * @param image The image (or transformer that will give the image) to draw
-     * @param options The options configuring how to draw the image
-     */
-    draw(image: ReadableStream<Uint8Array> | ImageTransformer, options?: ImageDrawOptions): ImageTransformer;
-    /**
-     * Retrieve the image that results from applying the transforms to the
-     * provided input
-     * @param options Options that apply to the output e.g. output format
-     */
-    output(options: ImageOutputOptions): Promise<ImageTransformationResult>;
+  /**
+   * Apply transform next, returning a transform handle.
+   * You can then apply more transformations, draw, or retrieve the output.
+   * @param transform
+   */
+  transform(transform: ImageTransform): ImageTransformer;
+  /**
+   * Draw an image on this transformer, returning a transform handle.
+   * You can then apply more transformations, draw, or retrieve the output.
+   * @param image The image (or transformer that will give the image) to draw
+   * @param options The options configuring how to draw the image
+   */
+  draw(
+    image: ReadableStream<Uint8Array> | ImageTransformer,
+    options?: ImageDrawOptions,
+  ): ImageTransformer;
+  /**
+   * Retrieve the image that results from applying the transforms to the
+   * provided input
+   * @param options Options that apply to the output e.g. output format
+   */
+  output(options: ImageOutputOptions): Promise<ImageTransformationResult>;
 }
 type ImageTransformationOutputOptions = {
-    encoding?: 'base64';
+  encoding?: "base64";
 };
 interface ImageTransformationResult {
-    /**
-     * The image as a response, ready to store in cache or return to users
-     */
-    response(): Response;
-    /**
-     * The content type of the returned image
-     */
-    contentType(): string;
-    /**
-     * The bytes of the response
-     */
-    image(options?: ImageTransformationOutputOptions): ReadableStream<Uint8Array>;
+  /**
+   * The image as a response, ready to store in cache or return to users
+   */
+  response(): Response;
+  /**
+   * The content type of the returned image
+   */
+  contentType(): string;
+  /**
+   * The bytes of the response
+   */
+  image(options?: ImageTransformationOutputOptions): ReadableStream<Uint8Array>;
 }
 interface ImagesError extends Error {
-    readonly code: number;
-    readonly message: string;
-    readonly stack?: string;
+  readonly code: number;
+  readonly message: string;
+  readonly stack?: string;
 }
 /**
  * Media binding for transforming media streams.
  * Provides the entry point for media transformation operations.
  */
 interface MediaBinding {
-    /**
-     * Creates a media transformer from an input stream.
-     * @param media - The input media bytes
-     * @returns A MediaTransformer instance for applying transformations
-     */
-    input(media: ReadableStream<Uint8Array>): MediaTransformer;
+  /**
+   * Creates a media transformer from an input stream.
+   * @param media - The input media bytes
+   * @returns A MediaTransformer instance for applying transformations
+   */
+  input(media: ReadableStream<Uint8Array>): MediaTransformer;
 }
 /**
  * Media transformer for applying transformation operations to media content.
  * Handles sizing, fitting, and other input transformation parameters.
  */
 interface MediaTransformer {
-    /**
-     * Applies transformation options to the media content.
-     * @param transform - Configuration for how the media should be transformed
-     * @returns A generator for producing the transformed media output
-     */
-    transform(transform: MediaTransformationInputOptions): MediaTransformationGenerator;
+  /**
+   * Applies transformation options to the media content.
+   * @param transform - Configuration for how the media should be transformed
+   * @returns A generator for producing the transformed media output
+   */
+  transform(transform: MediaTransformationInputOptions): MediaTransformationGenerator;
 }
 /**
  * Generator for producing media transformation results.
  * Configures the output format and parameters for the transformed media.
  */
 interface MediaTransformationGenerator {
-    /**
-     * Generates the final media output with specified options.
-     * @param output - Configuration for the output format and parameters
-     * @returns The final transformation result containing the transformed media
-     */
-    output(output: MediaTransformationOutputOptions): MediaTransformationResult;
+  /**
+   * Generates the final media output with specified options.
+   * @param output - Configuration for the output format and parameters
+   * @returns The final transformation result containing the transformed media
+   */
+  output(output: MediaTransformationOutputOptions): MediaTransformationResult;
 }
 /**
  * Result of a media transformation operation.
  * Provides multiple ways to access the transformed media content.
  */
 interface MediaTransformationResult {
-    /**
-     * Returns the transformed media as a readable stream of bytes.
-     * @returns A stream containing the transformed media data
-     */
-    media(): ReadableStream<Uint8Array>;
-    /**
-     * Returns the transformed media as an HTTP response object.
-     * @returns The transformed media as a Response, ready to store in cache or return to users
-     */
-    response(): Response;
-    /**
-     * Returns the MIME type of the transformed media.
-     * @returns The content type string (e.g., 'image/jpeg', 'video/mp4')
-     */
-    contentType(): string;
+  /**
+   * Returns the transformed media as a readable stream of bytes.
+   * @returns A stream containing the transformed media data
+   */
+  media(): ReadableStream<Uint8Array>;
+  /**
+   * Returns the transformed media as an HTTP response object.
+   * @returns The transformed media as a Response, ready to store in cache or return to users
+   */
+  response(): Response;
+  /**
+   * Returns the MIME type of the transformed media.
+   * @returns The content type string (e.g., 'image/jpeg', 'video/mp4')
+   */
+  contentType(): string;
 }
 /**
  * Configuration options for transforming media input.
  * Controls how the media should be resized and fitted.
  */
 type MediaTransformationInputOptions = {
-    /** How the media should be resized to fit the specified dimensions */
-    fit?: 'contain' | 'cover' | 'scale-down';
-    /** Target width in pixels */
-    width?: number;
-    /** Target height in pixels */
-    height?: number;
+  /** How the media should be resized to fit the specified dimensions */
+  fit?: "contain" | "cover" | "scale-down";
+  /** Target width in pixels */
+  width?: number;
+  /** Target height in pixels */
+  height?: number;
 };
 /**
  * Configuration options for Media Transformations output.
  * Controls the format, timing, and type of the generated output.
  */
 type MediaTransformationOutputOptions = {
-    /**
-     * Output mode determining the type of media to generate
-     */
-    mode?: 'video' | 'spritesheet' | 'frame' | 'audio';
-    /** Whether to include audio in the output */
-    audio?: boolean;
-    /**
-     * Starting timestamp for frame extraction or start time for clips. (e.g. '2s').
-     */
-    time?: string;
-    /**
-     * Duration for video clips, audio extraction, and spritesheet generation (e.g. '5s').
-     */
-    duration?: string;
-    /**
-     * Output format for the generated media.
-     */
-    format?: 'jpg' | 'png' | 'm4a';
+  /**
+   * Output mode determining the type of media to generate
+   */
+  mode?: "video" | "spritesheet" | "frame" | "audio";
+  /** Whether to include audio in the output */
+  audio?: boolean;
+  /**
+   * Starting timestamp for frame extraction or start time for clips. (e.g. '2s').
+   */
+  time?: string;
+  /**
+   * Duration for video clips, audio extraction, and spritesheet generation (e.g. '5s').
+   */
+  duration?: string;
+  /**
+   * Output format for the generated media.
+   */
+  format?: "jpg" | "png" | "m4a";
 };
 /**
  * Error object for media transformation operations.
  * Extends the standard Error interface with additional media-specific information.
  */
 interface MediaError extends Error {
-    readonly code: number;
-    readonly message: string;
-    readonly stack?: string;
+  readonly code: number;
+  readonly message: string;
+  readonly stack?: string;
 }
-declare module 'cloudflare:node' {
-    interface NodeStyleServer {
-        listen(...args: unknown[]): this;
-        address(): {
-            port?: number | null | undefined;
-        };
-    }
-    export function httpServerHandler(port: number): ExportedHandler;
-    export function httpServerHandler(options: {
-        port: number;
-    }): ExportedHandler;
-    export function httpServerHandler(server: NodeStyleServer): ExportedHandler;
+declare module "cloudflare:node" {
+  interface NodeStyleServer {
+    listen(...args: unknown[]): this;
+    address(): {
+      port?: number | null | undefined;
+    };
+  }
+  export function httpServerHandler(port: number): ExportedHandler;
+  export function httpServerHandler(options: { port: number }): ExportedHandler;
+  export function httpServerHandler(server: NodeStyleServer): ExportedHandler;
 }
 type Params<P extends string = any> = Record<P, string | string[]>;
 type EventContext<Env, P extends string, Data> = {
-    request: Request<unknown, IncomingRequestCfProperties<unknown>>;
-    functionPath: string;
-    waitUntil: (promise: Promise<any>) => void;
-    passThroughOnException: () => void;
-    next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
-    env: Env & {
-        ASSETS: {
-            fetch: typeof fetch;
-        };
+  request: Request<unknown, IncomingRequestCfProperties<unknown>>;
+  functionPath: string;
+  waitUntil: (promise: Promise<any>) => void;
+  passThroughOnException: () => void;
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  env: Env & {
+    ASSETS: {
+      fetch: typeof fetch;
     };
-    params: Params<P>;
-    data: Data;
+  };
+  params: Params<P>;
+  data: Data;
 };
-type PagesFunction<Env = unknown, Params extends string = any, Data extends Record<string, unknown> = Record<string, unknown>> = (context: EventContext<Env, Params, Data>) => Response | Promise<Response>;
+type PagesFunction<
+  Env = unknown,
+  Params extends string = any,
+  Data extends Record<string, unknown> = Record<string, unknown>,
+> = (context: EventContext<Env, Params, Data>) => Response | Promise<Response>;
 type EventPluginContext<Env, P extends string, Data, PluginArgs> = {
-    request: Request<unknown, IncomingRequestCfProperties<unknown>>;
-    functionPath: string;
-    waitUntil: (promise: Promise<any>) => void;
-    passThroughOnException: () => void;
-    next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
-    env: Env & {
-        ASSETS: {
-            fetch: typeof fetch;
-        };
+  request: Request<unknown, IncomingRequestCfProperties<unknown>>;
+  functionPath: string;
+  waitUntil: (promise: Promise<any>) => void;
+  passThroughOnException: () => void;
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  env: Env & {
+    ASSETS: {
+      fetch: typeof fetch;
     };
-    params: Params<P>;
-    data: Data;
-    pluginArgs: PluginArgs;
+  };
+  params: Params<P>;
+  data: Data;
+  pluginArgs: PluginArgs;
 };
-type PagesPluginFunction<Env = unknown, Params extends string = any, Data extends Record<string, unknown> = Record<string, unknown>, PluginArgs = unknown> = (context: EventPluginContext<Env, Params, Data, PluginArgs>) => Response | Promise<Response>;
+type PagesPluginFunction<
+  Env = unknown,
+  Params extends string = any,
+  Data extends Record<string, unknown> = Record<string, unknown>,
+  PluginArgs = unknown,
+> = (context: EventPluginContext<Env, Params, Data, PluginArgs>) => Response | Promise<Response>;
 declare module "assets:*" {
-    export const onRequest: PagesFunction;
+  export const onRequest: PagesFunction;
 }
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 declare module "cloudflare:pipelines" {
-    export abstract class PipelineTransformationEntrypoint<Env = unknown, I extends PipelineRecord = PipelineRecord, O extends PipelineRecord = PipelineRecord> {
-        protected env: Env;
-        protected ctx: ExecutionContext;
-        constructor(ctx: ExecutionContext, env: Env);
-        /**
-         * run recieves an array of PipelineRecord which can be
-         * transformed and returned to the pipeline
-         * @param records Incoming records from the pipeline to be transformed
-         * @param metadata Information about the specific pipeline calling the transformation entrypoint
-         * @returns A promise containing the transformed PipelineRecord array
-         */
-        public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
-    }
-    export type PipelineRecord = Record<string, unknown>;
-    export type PipelineBatchMetadata = {
-        pipelineId: string;
-        pipelineName: string;
-    };
-    export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
-        /**
-         * The Pipeline interface represents the type of a binding to a Pipeline
-         *
-         * @param records The records to send to the pipeline
-         */
-        send(records: T[]): Promise<void>;
-    }
+  export abstract class PipelineTransformationEntrypoint<
+    Env = unknown,
+    I extends PipelineRecord = PipelineRecord,
+    O extends PipelineRecord = PipelineRecord,
+  > {
+    protected env: Env;
+    protected ctx: ExecutionContext;
+    constructor(ctx: ExecutionContext, env: Env);
+    /**
+     * run recieves an array of PipelineRecord which can be
+     * transformed and returned to the pipeline
+     * @param records Incoming records from the pipeline to be transformed
+     * @param metadata Information about the specific pipeline calling the transformation entrypoint
+     * @returns A promise containing the transformed PipelineRecord array
+     */
+    public run(records: I[], metadata: PipelineBatchMetadata): Promise<O[]>;
+  }
+  export type PipelineRecord = Record<string, unknown>;
+  export type PipelineBatchMetadata = {
+    pipelineId: string;
+    pipelineName: string;
+  };
+  export interface Pipeline<T extends PipelineRecord = PipelineRecord> {
+    /**
+     * The Pipeline interface represents the type of a binding to a Pipeline
+     *
+     * @param records The records to send to the pipeline
+     */
+    send(records: T[]): Promise<void>;
+  }
 }
 // PubSubMessage represents an incoming PubSub message.
 // The message includes metadata about the broker, the client, and the payload
 // itself.
 // https://developers.cloudflare.com/pub-sub/
 interface PubSubMessage {
-    // Message ID
-    readonly mid: number;
-    // MQTT broker FQDN in the form mqtts://BROKER.NAMESPACE.cloudflarepubsub.com:PORT
-    readonly broker: string;
-    // The MQTT topic the message was sent on.
-    readonly topic: string;
-    // The client ID of the client that published this message.
-    readonly clientId: string;
-    // The unique identifier (JWT ID) used by the client to authenticate, if token
-    // auth was used.
-    readonly jti?: string;
-    // A Unix timestamp (seconds from Jan 1, 1970), set when the Pub/Sub Broker
-    // received the message from the client.
-    readonly receivedAt: number;
-    // An (optional) string with the MIME type of the payload, if set by the
-    // client.
-    readonly contentType: string;
-    // Set to 1 when the payload is a UTF-8 string
-    // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901063
-    readonly payloadFormatIndicator: number;
-    // Pub/Sub (MQTT) payloads can be UTF-8 strings, or byte arrays.
-    // You can use payloadFormatIndicator to inspect this before decoding.
-    payload: string | Uint8Array;
+  // Message ID
+  readonly mid: number;
+  // MQTT broker FQDN in the form mqtts://BROKER.NAMESPACE.cloudflarepubsub.com:PORT
+  readonly broker: string;
+  // The MQTT topic the message was sent on.
+  readonly topic: string;
+  // The client ID of the client that published this message.
+  readonly clientId: string;
+  // The unique identifier (JWT ID) used by the client to authenticate, if token
+  // auth was used.
+  readonly jti?: string;
+  // A Unix timestamp (seconds from Jan 1, 1970), set when the Pub/Sub Broker
+  // received the message from the client.
+  readonly receivedAt: number;
+  // An (optional) string with the MIME type of the payload, if set by the
+  // client.
+  readonly contentType: string;
+  // Set to 1 when the payload is a UTF-8 string
+  // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901063
+  readonly payloadFormatIndicator: number;
+  // Pub/Sub (MQTT) payloads can be UTF-8 strings, or byte arrays.
+  // You can use payloadFormatIndicator to inspect this before decoding.
+  payload: string | Uint8Array;
 }
 // JsonWebKey extended by kid parameter
 interface JsonWebKeyWithKid extends JsonWebKey {
-    // Key Identifier of the JWK
-    readonly kid: string;
+  // Key Identifier of the JWK
+  readonly kid: string;
 }
 interface RateLimitOptions {
-    key: string;
+  key: string;
 }
 interface RateLimitOutcome {
-    success: boolean;
+  success: boolean;
 }
 interface RateLimit {
-    /**
-     * Rate limit a request based on the provided options.
-     * @see https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
-     * @returns A promise that resolves with the outcome of the rate limit.
-     */
-    limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
+  /**
+   * Rate limit a request based on the provided options.
+   * @see https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+   * @returns A promise that resolves with the outcome of the rate limit.
+   */
+  limit(options: RateLimitOptions): Promise<RateLimitOutcome>;
 }
 // Namespace for RPC utility types. Unfortunately, we can't use a `module` here as these types need
 // to referenced by `Fetcher`. This is included in the "importable" version of the types which
 // strips all `module` blocks.
 declare namespace Rpc {
-    // Branded types for identifying `WorkerEntrypoint`/`DurableObject`/`Target`s.
-    // TypeScript uses *structural* typing meaning anything with the same shape as type `T` is a `T`.
-    // For the classes exported by `cloudflare:workers` we want *nominal* typing (i.e. we only want to
-    // accept `WorkerEntrypoint` from `cloudflare:workers`, not any other class with the same shape)
-    export const __RPC_STUB_BRAND: '__RPC_STUB_BRAND';
-    export const __RPC_TARGET_BRAND: '__RPC_TARGET_BRAND';
-    export const __WORKER_ENTRYPOINT_BRAND: '__WORKER_ENTRYPOINT_BRAND';
-    export const __DURABLE_OBJECT_BRAND: '__DURABLE_OBJECT_BRAND';
-    export const __WORKFLOW_ENTRYPOINT_BRAND: '__WORKFLOW_ENTRYPOINT_BRAND';
-    export interface RpcTargetBranded {
-        [__RPC_TARGET_BRAND]: never;
-    }
-    export interface WorkerEntrypointBranded {
-        [__WORKER_ENTRYPOINT_BRAND]: never;
-    }
-    export interface DurableObjectBranded {
-        [__DURABLE_OBJECT_BRAND]: never;
-    }
-    export interface WorkflowEntrypointBranded {
-        [__WORKFLOW_ENTRYPOINT_BRAND]: never;
-    }
-    export type EntrypointBranded = WorkerEntrypointBranded | DurableObjectBranded | WorkflowEntrypointBranded;
-    // Types that can be used through `Stub`s
-    export type Stubable = RpcTargetBranded | ((...args: any[]) => any);
-    // Types that can be passed over RPC
-    // The reason for using a generic type here is to build a serializable subset of structured
-    //   cloneable composite types. This allows types defined with the "interface" keyword to pass the
-    //   serializable check as well. Otherwise, only types defined with the "type" keyword would pass.
-    type Serializable<T> = 
+  // Branded types for identifying `WorkerEntrypoint`/`DurableObject`/`Target`s.
+  // TypeScript uses *structural* typing meaning anything with the same shape as type `T` is a `T`.
+  // For the classes exported by `cloudflare:workers` we want *nominal* typing (i.e. we only want to
+  // accept `WorkerEntrypoint` from `cloudflare:workers`, not any other class with the same shape)
+  export const __RPC_STUB_BRAND: "__RPC_STUB_BRAND";
+  export const __RPC_TARGET_BRAND: "__RPC_TARGET_BRAND";
+  export const __WORKER_ENTRYPOINT_BRAND: "__WORKER_ENTRYPOINT_BRAND";
+  export const __DURABLE_OBJECT_BRAND: "__DURABLE_OBJECT_BRAND";
+  export const __WORKFLOW_ENTRYPOINT_BRAND: "__WORKFLOW_ENTRYPOINT_BRAND";
+  export interface RpcTargetBranded {
+    [__RPC_TARGET_BRAND]: never;
+  }
+  export interface WorkerEntrypointBranded {
+    [__WORKER_ENTRYPOINT_BRAND]: never;
+  }
+  export interface DurableObjectBranded {
+    [__DURABLE_OBJECT_BRAND]: never;
+  }
+  export interface WorkflowEntrypointBranded {
+    [__WORKFLOW_ENTRYPOINT_BRAND]: never;
+  }
+  export type EntrypointBranded =
+    | WorkerEntrypointBranded
+    | DurableObjectBranded
+    | WorkflowEntrypointBranded;
+  // Types that can be used through `Stub`s
+  export type Stubable = RpcTargetBranded | ((...args: any[]) => any);
+  // Types that can be passed over RPC
+  // The reason for using a generic type here is to build a serializable subset of structured
+  //   cloneable composite types. This allows types defined with the "interface" keyword to pass the
+  //   serializable check as well. Otherwise, only types defined with the "type" keyword would pass.
+  type Serializable<T> =
     // Structured cloneables
-    BaseType
+    | BaseType
     // Structured cloneable composites
-     | Map<T extends Map<infer U, unknown> ? Serializable<U> : never, T extends Map<unknown, infer U> ? Serializable<U> : never> | Set<T extends Set<infer U> ? Serializable<U> : never> | ReadonlyArray<T extends ReadonlyArray<infer U> ? Serializable<U> : never> | {
+    | Map<
+        T extends Map<infer U, unknown> ? Serializable<U> : never,
+        T extends Map<unknown, infer U> ? Serializable<U> : never
+      >
+    | Set<T extends Set<infer U> ? Serializable<U> : never>
+    | ReadonlyArray<T extends ReadonlyArray<infer U> ? Serializable<U> : never>
+    | {
         [K in keyof T]: K extends number | string ? Serializable<T[K]> : never;
-    }
+      }
     // Special types
-     | Stub<Stubable>
+    | Stub<Stubable>
     // Serialized as stubs, see `Stubify`
-     | Stubable;
-    // Base type for all RPC stubs, including common memory management methods.
-    // `T` is used as a marker type for unwrapping `Stub`s later.
-    interface StubBase<T extends Stubable> extends Disposable {
-        [__RPC_STUB_BRAND]: T;
-        dup(): this;
-    }
-    export type Stub<T extends Stubable> = Provider<T> & StubBase<T>;
-    // This represents all the types that can be sent as-is over an RPC boundary
-    type BaseType = void | undefined | null | boolean | number | bigint | string | TypedArray | ArrayBuffer | DataView | Date | Error | RegExp | ReadableStream<Uint8Array> | WritableStream<Uint8Array> | Request | Response | Headers;
-    // Recursively rewrite all `Stubable` types with `Stub`s
-    // prettier-ignore
-    type Stubify<T> = T extends Stubable ? Stub<T> : T extends Map<infer K, infer V> ? Map<Stubify<K>, Stubify<V>> : T extends Set<infer V> ? Set<Stubify<V>> : T extends Array<infer V> ? Array<Stubify<V>> : T extends ReadonlyArray<infer V> ? ReadonlyArray<Stubify<V>> : T extends BaseType ? T : T extends {
+    | Stubable;
+  // Base type for all RPC stubs, including common memory management methods.
+  // `T` is used as a marker type for unwrapping `Stub`s later.
+  interface StubBase<T extends Stubable> extends Disposable {
+    [__RPC_STUB_BRAND]: T;
+    dup(): this;
+  }
+  export type Stub<T extends Stubable> = Provider<T> & StubBase<T>;
+  // This represents all the types that can be sent as-is over an RPC boundary
+  type BaseType =
+    | void
+    | undefined
+    | null
+    | boolean
+    | number
+    | bigint
+    | string
+    | TypedArray
+    | ArrayBuffer
+    | DataView
+    | Date
+    | Error
+    | RegExp
+    | ReadableStream<Uint8Array>
+    | WritableStream<Uint8Array>
+    | Request
+    | Response
+    | Headers;
+  // Recursively rewrite all `Stubable` types with `Stub`s
+  // prettier-ignore
+  type Stubify<T> = T extends Stubable ? Stub<T> : T extends Map<infer K, infer V> ? Map<Stubify<K>, Stubify<V>> : T extends Set<infer V> ? Set<Stubify<V>> : T extends Array<infer V> ? Array<Stubify<V>> : T extends ReadonlyArray<infer V> ? ReadonlyArray<Stubify<V>> : T extends BaseType ? T : T extends {
         [key: string | number]: any;
     } ? {
         [K in keyof T]: Stubify<T[K]>;
     } : T;
-    // Recursively rewrite all `Stub<T>`s with the corresponding `T`s.
-    // Note we use `StubBase` instead of `Stub` here to avoid circular dependencies:
-    // `Stub` depends on `Provider`, which depends on `Unstubify`, which would depend on `Stub`.
-    // prettier-ignore
-    type Unstubify<T> = T extends StubBase<infer V> ? V : T extends Map<infer K, infer V> ? Map<Unstubify<K>, Unstubify<V>> : T extends Set<infer V> ? Set<Unstubify<V>> : T extends Array<infer V> ? Array<Unstubify<V>> : T extends ReadonlyArray<infer V> ? ReadonlyArray<Unstubify<V>> : T extends BaseType ? T : T extends {
+  // Recursively rewrite all `Stub<T>`s with the corresponding `T`s.
+  // Note we use `StubBase` instead of `Stub` here to avoid circular dependencies:
+  // `Stub` depends on `Provider`, which depends on `Unstubify`, which would depend on `Stub`.
+  // prettier-ignore
+  type Unstubify<T> = T extends StubBase<infer V> ? V : T extends Map<infer K, infer V> ? Map<Unstubify<K>, Unstubify<V>> : T extends Set<infer V> ? Set<Unstubify<V>> : T extends Array<infer V> ? Array<Unstubify<V>> : T extends ReadonlyArray<infer V> ? ReadonlyArray<Unstubify<V>> : T extends BaseType ? T : T extends {
         [key: string | number]: unknown;
     } ? {
         [K in keyof T]: Unstubify<T[K]>;
     } : T;
-    type UnstubifyAll<A extends any[]> = {
-        [I in keyof A]: Unstubify<A[I]>;
-    };
-    // Utility type for adding `Provider`/`Disposable`s to `object` types only.
-    // Note `unknown & T` is equivalent to `T`.
-    type MaybeProvider<T> = T extends object ? Provider<T> : unknown;
-    type MaybeDisposable<T> = T extends object ? Disposable : unknown;
-    // Type for method return or property on an RPC interface.
-    // - Stubable types are replaced by stubs.
-    // - Serializable types are passed by value, with stubable types replaced by stubs
-    //   and a top-level `Disposer`.
-    // Everything else can't be passed over PRC.
-    // Technically, we use custom thenables here, but they quack like `Promise`s.
-    // Intersecting with `(Maybe)Provider` allows pipelining.
-    // prettier-ignore
-    type Result<R> = R extends Stubable ? Promise<Stub<R>> & Provider<R> : R extends Serializable<R> ? Promise<Stubify<R> & MaybeDisposable<R>> & MaybeProvider<R> : never;
-    // Type for method or property on an RPC interface.
-    // For methods, unwrap `Stub`s in parameters, and rewrite returns to be `Result`s.
-    // Unwrapping `Stub`s allows calling with `Stubable` arguments.
-    // For properties, rewrite types to be `Result`s.
-    // In each case, unwrap `Promise`s.
-    type MethodOrProperty<V> = V extends (...args: infer P) => infer R ? (...args: UnstubifyAll<P>) => Result<Awaited<R>> : Result<Awaited<V>>;
-    // Type for the callable part of an `Provider` if `T` is callable.
-    // This is intersected with methods/properties.
-    type MaybeCallableProvider<T> = T extends (...args: any[]) => any ? MethodOrProperty<T> : unknown;
-    // Base type for all other types providing RPC-like interfaces.
-    // Rewrites all methods/properties to be `MethodOrProperty`s, while preserving callable types.
-    // `Reserved` names (e.g. stub method names like `dup()`) and symbols can't be accessed over RPC.
-    export type Provider<T extends object, Reserved extends string = never> = MaybeCallableProvider<T> & {
-        [K in Exclude<keyof T, Reserved | symbol | keyof StubBase<never>>]: MethodOrProperty<T[K]>;
-    };
+  type UnstubifyAll<A extends any[]> = {
+    [I in keyof A]: Unstubify<A[I]>;
+  };
+  // Utility type for adding `Provider`/`Disposable`s to `object` types only.
+  // Note `unknown & T` is equivalent to `T`.
+  type MaybeProvider<T> = T extends object ? Provider<T> : unknown;
+  type MaybeDisposable<T> = T extends object ? Disposable : unknown;
+  // Type for method return or property on an RPC interface.
+  // - Stubable types are replaced by stubs.
+  // - Serializable types are passed by value, with stubable types replaced by stubs
+  //   and a top-level `Disposer`.
+  // Everything else can't be passed over PRC.
+  // Technically, we use custom thenables here, but they quack like `Promise`s.
+  // Intersecting with `(Maybe)Provider` allows pipelining.
+  // prettier-ignore
+  type Result<R> = R extends Stubable ? Promise<Stub<R>> & Provider<R> : R extends Serializable<R> ? Promise<Stubify<R> & MaybeDisposable<R>> & MaybeProvider<R> : never;
+  // Type for method or property on an RPC interface.
+  // For methods, unwrap `Stub`s in parameters, and rewrite returns to be `Result`s.
+  // Unwrapping `Stub`s allows calling with `Stubable` arguments.
+  // For properties, rewrite types to be `Result`s.
+  // In each case, unwrap `Promise`s.
+  type MethodOrProperty<V> = V extends (...args: infer P) => infer R
+    ? (...args: UnstubifyAll<P>) => Result<Awaited<R>>
+    : Result<Awaited<V>>;
+  // Type for the callable part of an `Provider` if `T` is callable.
+  // This is intersected with methods/properties.
+  type MaybeCallableProvider<T> = T extends (...args: any[]) => any ? MethodOrProperty<T> : unknown;
+  // Base type for all other types providing RPC-like interfaces.
+  // Rewrites all methods/properties to be `MethodOrProperty`s, while preserving callable types.
+  // `Reserved` names (e.g. stub method names like `dup()`) and symbols can't be accessed over RPC.
+  export type Provider<
+    T extends object,
+    Reserved extends string = never,
+  > = MaybeCallableProvider<T> & {
+    [K in Exclude<keyof T, Reserved | symbol | keyof StubBase<never>>]: MethodOrProperty<T[K]>;
+  };
 }
 declare namespace Cloudflare {
-    // Type of `env`.
-    //
-    // The specific project can extend `Env` by redeclaring it in project-specific files. Typescript
-    // will merge all declarations.
-    //
-    // You can use `wrangler types` to generate the `Env` type automatically.
-    interface Env {
-    }
-    // Project-specific parameters used to inform types.
-    //
-    // This interface is, again, intended to be declared in project-specific files, and then that
-    // declaration will be merged with this one.
-    //
-    // A project should have a declaration like this:
-    //
-    //     interface GlobalProps {
-    //       // Declares the main module's exports. Used to populate Cloudflare.Exports aka the type
-    //       // of `ctx.exports`.
-    //       mainModule: typeof import("my-main-module");
-    //
-    //       // Declares which of the main module's exports are configured with durable storage, and
-    //       // thus should behave as Durable Object namsepace bindings.
-    //       durableNamespaces: "MyDurableObject" | "AnotherDurableObject";
-    //     }
-    //
-    // You can use `wrangler types` to generate `GlobalProps` automatically.
-    interface GlobalProps {
-    }
-    // Evaluates to the type of a property in GlobalProps, defaulting to `Default` if it is not
-    // present.
-    type GlobalProp<K extends string, Default> = K extends keyof GlobalProps ? GlobalProps[K] : Default;
-    // The type of the program's main module exports, if known. Requires `GlobalProps` to declare the
-    // `mainModule` property.
-    type MainModule = GlobalProp<"mainModule", {}>;
-    // The type of ctx.exports, which contains loopback bindings for all top-level exports.
-    type Exports = {
-        [K in keyof MainModule]: LoopbackForExport<MainModule[K]>
-        // If the export is listed in `durableNamespaces`, then it is also a
-        // DurableObjectNamespace.
-         & (K extends GlobalProp<"durableNamespaces", never> ? MainModule[K] extends new (...args: any[]) => infer DoInstance ? DoInstance extends Rpc.DurableObjectBranded ? DurableObjectNamespace<DoInstance> : DurableObjectNamespace<undefined> : DurableObjectNamespace<undefined> : {});
-    };
+  // Type of `env`.
+  //
+  // The specific project can extend `Env` by redeclaring it in project-specific files. Typescript
+  // will merge all declarations.
+  //
+  // You can use `wrangler types` to generate the `Env` type automatically.
+  interface Env {}
+  // Project-specific parameters used to inform types.
+  //
+  // This interface is, again, intended to be declared in project-specific files, and then that
+  // declaration will be merged with this one.
+  //
+  // A project should have a declaration like this:
+  //
+  //     interface GlobalProps {
+  //       // Declares the main module's exports. Used to populate Cloudflare.Exports aka the type
+  //       // of `ctx.exports`.
+  //       mainModule: typeof import("my-main-module");
+  //
+  //       // Declares which of the main module's exports are configured with durable storage, and
+  //       // thus should behave as Durable Object namsepace bindings.
+  //       durableNamespaces: "MyDurableObject" | "AnotherDurableObject";
+  //     }
+  //
+  // You can use `wrangler types` to generate `GlobalProps` automatically.
+  interface GlobalProps {}
+  // Evaluates to the type of a property in GlobalProps, defaulting to `Default` if it is not
+  // present.
+  type GlobalProp<K extends string, Default> = K extends keyof GlobalProps
+    ? GlobalProps[K]
+    : Default;
+  // The type of the program's main module exports, if known. Requires `GlobalProps` to declare the
+  // `mainModule` property.
+  type MainModule = GlobalProp<"mainModule", {}>;
+  // The type of ctx.exports, which contains loopback bindings for all top-level exports.
+  type Exports = {
+    [K in keyof MainModule]: LoopbackForExport<MainModule[K]> &
+      // If the export is listed in `durableNamespaces`, then it is also a
+      // DurableObjectNamespace.
+      (K extends GlobalProp<"durableNamespaces", never>
+        ? MainModule[K] extends new (...args: any[]) => infer DoInstance
+          ? DoInstance extends Rpc.DurableObjectBranded
+            ? DurableObjectNamespace<DoInstance>
+            : DurableObjectNamespace<undefined>
+          : DurableObjectNamespace<undefined>
+        : {});
+  };
 }
 declare namespace CloudflareWorkersModule {
-    export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
-    export const RpcStub: {
-        new <T extends Rpc.Stubable>(value: T): Rpc.Stub<T>;
+  export type RpcStub<T extends Rpc.Stubable> = Rpc.Stub<T>;
+  export const RpcStub: {
+    new <T extends Rpc.Stubable>(value: T): Rpc.Stub<T>;
+  };
+  export abstract class RpcTarget implements Rpc.RpcTargetBranded {
+    [Rpc.__RPC_TARGET_BRAND]: never;
+  }
+  // `protected` fields don't appear in `keyof`s, so can't be accessed over RPC
+  export abstract class WorkerEntrypoint<Env = Cloudflare.Env, Props = {}>
+    implements Rpc.WorkerEntrypointBranded
+  {
+    [Rpc.__WORKER_ENTRYPOINT_BRAND]: never;
+    protected ctx: ExecutionContext<Props>;
+    protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
+    fetch?(request: Request): Response | Promise<Response>;
+    tail?(events: TraceItem[]): void | Promise<void>;
+    trace?(traces: TraceItem[]): void | Promise<void>;
+    scheduled?(controller: ScheduledController): void | Promise<void>;
+    queue?(batch: MessageBatch<unknown>): void | Promise<void>;
+    test?(controller: TestController): void | Promise<void>;
+  }
+  export abstract class DurableObject<Env = Cloudflare.Env, Props = {}>
+    implements Rpc.DurableObjectBranded
+  {
+    [Rpc.__DURABLE_OBJECT_BRAND]: never;
+    protected ctx: DurableObjectState<Props>;
+    protected env: Env;
+    constructor(ctx: DurableObjectState, env: Env);
+    fetch?(request: Request): Response | Promise<Response>;
+    alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
+    webSocketMessage?(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void>;
+    webSocketClose?(
+      ws: WebSocket,
+      code: number,
+      reason: string,
+      wasClean: boolean,
+    ): void | Promise<void>;
+    webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
+  }
+  export type WorkflowDurationLabel =
+    | "second"
+    | "minute"
+    | "hour"
+    | "day"
+    | "week"
+    | "month"
+    | "year";
+  export type WorkflowSleepDuration = `${number} ${WorkflowDurationLabel}${"s" | ""}` | number;
+  export type WorkflowDelayDuration = WorkflowSleepDuration;
+  export type WorkflowTimeoutDuration = WorkflowSleepDuration;
+  export type WorkflowRetentionDuration = WorkflowSleepDuration;
+  export type WorkflowBackoff = "constant" | "linear" | "exponential";
+  export type WorkflowStepConfig = {
+    retries?: {
+      limit: number;
+      delay: WorkflowDelayDuration | number;
+      backoff?: WorkflowBackoff;
     };
-    export abstract class RpcTarget implements Rpc.RpcTargetBranded {
-        [Rpc.__RPC_TARGET_BRAND]: never;
-    }
-    // `protected` fields don't appear in `keyof`s, so can't be accessed over RPC
-    export abstract class WorkerEntrypoint<Env = Cloudflare.Env, Props = {}> implements Rpc.WorkerEntrypointBranded {
-        [Rpc.__WORKER_ENTRYPOINT_BRAND]: never;
-        protected ctx: ExecutionContext<Props>;
-        protected env: Env;
-        constructor(ctx: ExecutionContext, env: Env);
-        fetch?(request: Request): Response | Promise<Response>;
-        tail?(events: TraceItem[]): void | Promise<void>;
-        trace?(traces: TraceItem[]): void | Promise<void>;
-        scheduled?(controller: ScheduledController): void | Promise<void>;
-        queue?(batch: MessageBatch<unknown>): void | Promise<void>;
-        test?(controller: TestController): void | Promise<void>;
-    }
-    export abstract class DurableObject<Env = Cloudflare.Env, Props = {}> implements Rpc.DurableObjectBranded {
-        [Rpc.__DURABLE_OBJECT_BRAND]: never;
-        protected ctx: DurableObjectState<Props>;
-        protected env: Env;
-        constructor(ctx: DurableObjectState, env: Env);
-        fetch?(request: Request): Response | Promise<Response>;
-        alarm?(alarmInfo?: AlarmInvocationInfo): void | Promise<void>;
-        webSocketMessage?(ws: WebSocket, message: string | ArrayBuffer): void | Promise<void>;
-        webSocketClose?(ws: WebSocket, code: number, reason: string, wasClean: boolean): void | Promise<void>;
-        webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
-    }
-    export type WorkflowDurationLabel = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
-    export type WorkflowSleepDuration = `${number} ${WorkflowDurationLabel}${'s' | ''}` | number;
-    export type WorkflowDelayDuration = WorkflowSleepDuration;
-    export type WorkflowTimeoutDuration = WorkflowSleepDuration;
-    export type WorkflowRetentionDuration = WorkflowSleepDuration;
-    export type WorkflowBackoff = 'constant' | 'linear' | 'exponential';
-    export type WorkflowStepConfig = {
-        retries?: {
-            limit: number;
-            delay: WorkflowDelayDuration | number;
-            backoff?: WorkflowBackoff;
-        };
-        timeout?: WorkflowTimeoutDuration | number;
-    };
-    export type WorkflowEvent<T> = {
-        payload: Readonly<T>;
-        timestamp: Date;
-        instanceId: string;
-    };
-    export type WorkflowStepEvent<T> = {
-        payload: Readonly<T>;
-        timestamp: Date;
+    timeout?: WorkflowTimeoutDuration | number;
+  };
+  export type WorkflowEvent<T> = {
+    payload: Readonly<T>;
+    timestamp: Date;
+    instanceId: string;
+  };
+  export type WorkflowStepEvent<T> = {
+    payload: Readonly<T>;
+    timestamp: Date;
+    type: string;
+  };
+  export abstract class WorkflowStep {
+    do<T extends Rpc.Serializable<T>>(name: string, callback: () => Promise<T>): Promise<T>;
+    do<T extends Rpc.Serializable<T>>(
+      name: string,
+      config: WorkflowStepConfig,
+      callback: () => Promise<T>,
+    ): Promise<T>;
+    sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
+    sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
+    waitForEvent<T extends Rpc.Serializable<T>>(
+      name: string,
+      options: {
         type: string;
-    };
-    export abstract class WorkflowStep {
-        do<T extends Rpc.Serializable<T>>(name: string, callback: () => Promise<T>): Promise<T>;
-        do<T extends Rpc.Serializable<T>>(name: string, config: WorkflowStepConfig, callback: () => Promise<T>): Promise<T>;
-        sleep: (name: string, duration: WorkflowSleepDuration) => Promise<void>;
-        sleepUntil: (name: string, timestamp: Date | number) => Promise<void>;
-        waitForEvent<T extends Rpc.Serializable<T>>(name: string, options: {
-            type: string;
-            timeout?: WorkflowTimeoutDuration | number;
-        }): Promise<WorkflowStepEvent<T>>;
-    }
-    export abstract class WorkflowEntrypoint<Env = unknown, T extends Rpc.Serializable<T> | unknown = unknown> implements Rpc.WorkflowEntrypointBranded {
-        [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
-        protected ctx: ExecutionContext;
-        protected env: Env;
-        constructor(ctx: ExecutionContext, env: Env);
-        run(event: Readonly<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
-    }
-    export function waitUntil(promise: Promise<unknown>): void;
-    export const env: Cloudflare.Env;
+        timeout?: WorkflowTimeoutDuration | number;
+      },
+    ): Promise<WorkflowStepEvent<T>>;
+  }
+  export abstract class WorkflowEntrypoint<
+    Env = unknown,
+    T extends Rpc.Serializable<T> | unknown = unknown,
+  > implements Rpc.WorkflowEntrypointBranded
+  {
+    [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
+    protected ctx: ExecutionContext;
+    protected env: Env;
+    constructor(ctx: ExecutionContext, env: Env);
+    run(event: Readonly<WorkflowEvent<T>>, step: WorkflowStep): Promise<unknown>;
+  }
+  export function waitUntil(promise: Promise<unknown>): void;
+  export const env: Cloudflare.Env;
 }
-declare module 'cloudflare:workers' {
-    export = CloudflareWorkersModule;
+declare module "cloudflare:workers" {
+  export = CloudflareWorkersModule;
 }
 interface SecretsStoreSecret {
-    /**
-     * Get a secret from the Secrets Store, returning a string of the secret value
-     * if it exists, or throws an error if it does not exist
-     */
-    get(): Promise<string>;
+  /**
+   * Get a secret from the Secrets Store, returning a string of the secret value
+   * if it exists, or throws an error if it does not exist
+   */
+  get(): Promise<string>;
 }
 declare module "cloudflare:sockets" {
-    function _connect(address: string | SocketAddress, options?: SocketOptions): Socket;
-    export { _connect as connect };
+  function _connect(address: string | SocketAddress, options?: SocketOptions): Socket;
+  export { _connect as connect };
 }
 declare namespace TailStream {
-    interface Header {
-        readonly name: string;
-        readonly value: string;
-    }
-    interface FetchEventInfo {
-        readonly type: "fetch";
-        readonly method: string;
-        readonly url: string;
-        readonly cfJson?: object;
-        readonly headers: Header[];
-    }
-    interface JsRpcEventInfo {
-        readonly type: "jsrpc";
-    }
-    interface ScheduledEventInfo {
-        readonly type: "scheduled";
-        readonly scheduledTime: Date;
-        readonly cron: string;
-    }
-    interface AlarmEventInfo {
-        readonly type: "alarm";
-        readonly scheduledTime: Date;
-    }
-    interface QueueEventInfo {
-        readonly type: "queue";
-        readonly queueName: string;
-        readonly batchSize: number;
-    }
-    interface EmailEventInfo {
-        readonly type: "email";
-        readonly mailFrom: string;
-        readonly rcptTo: string;
-        readonly rawSize: number;
-    }
-    interface TraceEventInfo {
-        readonly type: "trace";
-        readonly traces: (string | null)[];
-    }
-    interface HibernatableWebSocketEventInfoMessage {
-        readonly type: "message";
-    }
-    interface HibernatableWebSocketEventInfoError {
-        readonly type: "error";
-    }
-    interface HibernatableWebSocketEventInfoClose {
-        readonly type: "close";
-        readonly code: number;
-        readonly wasClean: boolean;
-    }
-    interface HibernatableWebSocketEventInfo {
-        readonly type: "hibernatableWebSocket";
-        readonly info: HibernatableWebSocketEventInfoClose | HibernatableWebSocketEventInfoError | HibernatableWebSocketEventInfoMessage;
-    }
-    interface CustomEventInfo {
-        readonly type: "custom";
-    }
-    interface FetchResponseInfo {
-        readonly type: "fetch";
-        readonly statusCode: number;
-    }
-    type EventOutcome = "ok" | "canceled" | "exception" | "unknown" | "killSwitch" | "daemonDown" | "exceededCpu" | "exceededMemory" | "loadShed" | "responseStreamDisconnected" | "scriptNotFound";
-    interface ScriptVersion {
-        readonly id: string;
-        readonly tag?: string;
-        readonly message?: string;
-    }
-    interface Onset {
-        readonly type: "onset";
-        readonly attributes: Attribute[];
-        // id for the span being opened by this Onset event.
-        readonly spanId: string;
-        readonly dispatchNamespace?: string;
-        readonly entrypoint?: string;
-        readonly executionModel: string;
-        readonly scriptName?: string;
-        readonly scriptTags?: string[];
-        readonly scriptVersion?: ScriptVersion;
-        readonly info: FetchEventInfo | JsRpcEventInfo | ScheduledEventInfo | AlarmEventInfo | QueueEventInfo | EmailEventInfo | TraceEventInfo | HibernatableWebSocketEventInfo | CustomEventInfo;
-    }
-    interface Outcome {
-        readonly type: "outcome";
-        readonly outcome: EventOutcome;
-        readonly cpuTime: number;
-        readonly wallTime: number;
-    }
-    interface SpanOpen {
-        readonly type: "spanOpen";
-        readonly name: string;
-        // id for the span being opened by this SpanOpen event.
-        readonly spanId: string;
-        readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
-    }
-    interface SpanClose {
-        readonly type: "spanClose";
-        readonly outcome: EventOutcome;
-    }
-    interface DiagnosticChannelEvent {
-        readonly type: "diagnosticChannel";
-        readonly channel: string;
-        readonly message: any;
-    }
-    interface Exception {
-        readonly type: "exception";
-        readonly name: string;
-        readonly message: string;
-        readonly stack?: string;
-    }
-    interface Log {
-        readonly type: "log";
-        readonly level: "debug" | "error" | "info" | "log" | "warn";
-        readonly message: object;
-    }
-    // This marks the worker handler return information.
-    // This is separate from Outcome because the worker invocation can live for a long time after
-    // returning. For example - Websockets that return an http upgrade response but then continue
-    // streaming information or SSE http connections.
-    interface Return {
-        readonly type: "return";
-        readonly info?: FetchResponseInfo;
-    }
-    interface Attribute {
-        readonly name: string;
-        readonly value: string | string[] | boolean | boolean[] | number | number[] | bigint | bigint[];
-    }
-    interface Attributes {
-        readonly type: "attributes";
-        readonly info: Attribute[];
-    }
-    type EventType = Onset | Outcome | SpanOpen | SpanClose | DiagnosticChannelEvent | Exception | Log | Return | Attributes;
-    // Context in which this trace event lives.
-    interface SpanContext {
-        // Single id for the entire top-level invocation
-        // This should be a new traceId for the first worker stage invoked in the eyeball request and then
-        // same-account service-bindings should reuse the same traceId but cross-account service-bindings
-        // should use a new traceId.
-        readonly traceId: string;
-        // spanId in which this event is handled
-        // for Onset and SpanOpen events this would be the parent span id
-        // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
-        // For Hibernate and Mark this would be the span under which they were emitted.
-        // spanId is not set ONLY if:
-        //  1. This is an Onset event
-        //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
-        readonly spanId?: string;
-    }
-    interface TailEvent<Event extends EventType> {
-        // invocation id of the currently invoked worker stage.
-        // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
-        readonly invocationId: string;
-        // Inherited spanContext for this event.
-        readonly spanContext: SpanContext;
-        readonly timestamp: Date;
-        readonly sequence: number;
-        readonly event: Event;
-    }
-    type TailEventHandler<Event extends EventType = EventType> = (event: TailEvent<Event>) => void | Promise<void>;
-    type TailEventHandlerObject = {
-        outcome?: TailEventHandler<Outcome>;
-        spanOpen?: TailEventHandler<SpanOpen>;
-        spanClose?: TailEventHandler<SpanClose>;
-        diagnosticChannel?: TailEventHandler<DiagnosticChannelEvent>;
-        exception?: TailEventHandler<Exception>;
-        log?: TailEventHandler<Log>;
-        return?: TailEventHandler<Return>;
-        attributes?: TailEventHandler<Attributes>;
-    };
-    type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
+  interface Header {
+    readonly name: string;
+    readonly value: string;
+  }
+  interface FetchEventInfo {
+    readonly type: "fetch";
+    readonly method: string;
+    readonly url: string;
+    readonly cfJson?: object;
+    readonly headers: Header[];
+  }
+  interface JsRpcEventInfo {
+    readonly type: "jsrpc";
+  }
+  interface ScheduledEventInfo {
+    readonly type: "scheduled";
+    readonly scheduledTime: Date;
+    readonly cron: string;
+  }
+  interface AlarmEventInfo {
+    readonly type: "alarm";
+    readonly scheduledTime: Date;
+  }
+  interface QueueEventInfo {
+    readonly type: "queue";
+    readonly queueName: string;
+    readonly batchSize: number;
+  }
+  interface EmailEventInfo {
+    readonly type: "email";
+    readonly mailFrom: string;
+    readonly rcptTo: string;
+    readonly rawSize: number;
+  }
+  interface TraceEventInfo {
+    readonly type: "trace";
+    readonly traces: (string | null)[];
+  }
+  interface HibernatableWebSocketEventInfoMessage {
+    readonly type: "message";
+  }
+  interface HibernatableWebSocketEventInfoError {
+    readonly type: "error";
+  }
+  interface HibernatableWebSocketEventInfoClose {
+    readonly type: "close";
+    readonly code: number;
+    readonly wasClean: boolean;
+  }
+  interface HibernatableWebSocketEventInfo {
+    readonly type: "hibernatableWebSocket";
+    readonly info:
+      | HibernatableWebSocketEventInfoClose
+      | HibernatableWebSocketEventInfoError
+      | HibernatableWebSocketEventInfoMessage;
+  }
+  interface CustomEventInfo {
+    readonly type: "custom";
+  }
+  interface FetchResponseInfo {
+    readonly type: "fetch";
+    readonly statusCode: number;
+  }
+  type EventOutcome =
+    | "ok"
+    | "canceled"
+    | "exception"
+    | "unknown"
+    | "killSwitch"
+    | "daemonDown"
+    | "exceededCpu"
+    | "exceededMemory"
+    | "loadShed"
+    | "responseStreamDisconnected"
+    | "scriptNotFound";
+  interface ScriptVersion {
+    readonly id: string;
+    readonly tag?: string;
+    readonly message?: string;
+  }
+  interface Onset {
+    readonly type: "onset";
+    readonly attributes: Attribute[];
+    // id for the span being opened by this Onset event.
+    readonly spanId: string;
+    readonly dispatchNamespace?: string;
+    readonly entrypoint?: string;
+    readonly executionModel: string;
+    readonly scriptName?: string;
+    readonly scriptTags?: string[];
+    readonly scriptVersion?: ScriptVersion;
+    readonly info:
+      | FetchEventInfo
+      | JsRpcEventInfo
+      | ScheduledEventInfo
+      | AlarmEventInfo
+      | QueueEventInfo
+      | EmailEventInfo
+      | TraceEventInfo
+      | HibernatableWebSocketEventInfo
+      | CustomEventInfo;
+  }
+  interface Outcome {
+    readonly type: "outcome";
+    readonly outcome: EventOutcome;
+    readonly cpuTime: number;
+    readonly wallTime: number;
+  }
+  interface SpanOpen {
+    readonly type: "spanOpen";
+    readonly name: string;
+    // id for the span being opened by this SpanOpen event.
+    readonly spanId: string;
+    readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
+  }
+  interface SpanClose {
+    readonly type: "spanClose";
+    readonly outcome: EventOutcome;
+  }
+  interface DiagnosticChannelEvent {
+    readonly type: "diagnosticChannel";
+    readonly channel: string;
+    readonly message: any;
+  }
+  interface Exception {
+    readonly type: "exception";
+    readonly name: string;
+    readonly message: string;
+    readonly stack?: string;
+  }
+  interface Log {
+    readonly type: "log";
+    readonly level: "debug" | "error" | "info" | "log" | "warn";
+    readonly message: object;
+  }
+  // This marks the worker handler return information.
+  // This is separate from Outcome because the worker invocation can live for a long time after
+  // returning. For example - Websockets that return an http upgrade response but then continue
+  // streaming information or SSE http connections.
+  interface Return {
+    readonly type: "return";
+    readonly info?: FetchResponseInfo;
+  }
+  interface Attribute {
+    readonly name: string;
+    readonly value: string | string[] | boolean | boolean[] | number | number[] | bigint | bigint[];
+  }
+  interface Attributes {
+    readonly type: "attributes";
+    readonly info: Attribute[];
+  }
+  type EventType =
+    | Onset
+    | Outcome
+    | SpanOpen
+    | SpanClose
+    | DiagnosticChannelEvent
+    | Exception
+    | Log
+    | Return
+    | Attributes;
+  // Context in which this trace event lives.
+  interface SpanContext {
+    // Single id for the entire top-level invocation
+    // This should be a new traceId for the first worker stage invoked in the eyeball request and then
+    // same-account service-bindings should reuse the same traceId but cross-account service-bindings
+    // should use a new traceId.
+    readonly traceId: string;
+    // spanId in which this event is handled
+    // for Onset and SpanOpen events this would be the parent span id
+    // for Outcome and SpanClose these this would be the span id of the opening Onset and SpanOpen events
+    // For Hibernate and Mark this would be the span under which they were emitted.
+    // spanId is not set ONLY if:
+    //  1. This is an Onset event
+    //  2. We are not inherting any SpanContext. (e.g. this is a cross-account service binding or a new top-level invocation)
+    readonly spanId?: string;
+  }
+  interface TailEvent<Event extends EventType> {
+    // invocation id of the currently invoked worker stage.
+    // invocation id will always be unique to every Onset event and will be the same until the Outcome event.
+    readonly invocationId: string;
+    // Inherited spanContext for this event.
+    readonly spanContext: SpanContext;
+    readonly timestamp: Date;
+    readonly sequence: number;
+    readonly event: Event;
+  }
+  type TailEventHandler<Event extends EventType = EventType> = (
+    event: TailEvent<Event>,
+  ) => void | Promise<void>;
+  type TailEventHandlerObject = {
+    outcome?: TailEventHandler<Outcome>;
+    spanOpen?: TailEventHandler<SpanOpen>;
+    spanClose?: TailEventHandler<SpanClose>;
+    diagnosticChannel?: TailEventHandler<DiagnosticChannelEvent>;
+    exception?: TailEventHandler<Exception>;
+    log?: TailEventHandler<Log>;
+    return?: TailEventHandler<Return>;
+    attributes?: TailEventHandler<Attributes>;
+  };
+  type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }
 // Copyright (c) 2022-2023 Cloudflare, Inc.
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
@@ -7978,11 +8886,13 @@ type VectorizeVectorMetadataValue = string | number | boolean | string[];
 /**
  * Additional information to associate with a vector.
  */
-type VectorizeVectorMetadata = VectorizeVectorMetadataValue | Record<string, VectorizeVectorMetadataValue>;
+type VectorizeVectorMetadata =
+  | VectorizeVectorMetadataValue
+  | Record<string, VectorizeVectorMetadataValue>;
 type VectorFloatArray = Float32Array | Float64Array;
 interface VectorizeError {
-    code?: number;
-    error: string;
+  code?: number;
+  error: string;
 }
 /**
  * Comparison logic/operation to use for metadata filtering.
@@ -7994,9 +8904,15 @@ type VectorizeVectorMetadataFilterOp = "$eq" | "$ne";
  * Filter criteria for vector metadata used to limit the retrieved query result set.
  */
 type VectorizeVectorMetadataFilter = {
-    [field: string]: Exclude<VectorizeVectorMetadataValue, string[]> | null | {
-        [Op in VectorizeVectorMetadataFilterOp]?: Exclude<VectorizeVectorMetadataValue, string[]> | null;
-    };
+  [field: string]:
+    | Exclude<VectorizeVectorMetadataValue, string[]>
+    | null
+    | {
+        [Op in VectorizeVectorMetadataFilterOp]?: Exclude<
+          VectorizeVectorMetadataValue,
+          string[]
+        > | null;
+      };
 };
 /**
  * Supported distance metrics for an index.
@@ -8014,21 +8930,23 @@ type VectorizeDistanceMetric = "euclidean" | "cosine" | "dot-product";
  */
 type VectorizeMetadataRetrievalLevel = "all" | "indexed" | "none";
 interface VectorizeQueryOptions {
-    topK?: number;
-    namespace?: string;
-    returnValues?: boolean;
-    returnMetadata?: boolean | VectorizeMetadataRetrievalLevel;
-    filter?: VectorizeVectorMetadataFilter;
+  topK?: number;
+  namespace?: string;
+  returnValues?: boolean;
+  returnMetadata?: boolean | VectorizeMetadataRetrievalLevel;
+  filter?: VectorizeVectorMetadataFilter;
 }
 /**
  * Information about the configuration of an index.
  */
-type VectorizeIndexConfig = {
-    dimensions: number;
-    metric: VectorizeDistanceMetric;
-} | {
-    preset: string; // keep this generic, as we'll be adding more presets in the future and this is only in a read capacity
-};
+type VectorizeIndexConfig =
+  | {
+      dimensions: number;
+      metric: VectorizeDistanceMetric;
+    }
+  | {
+      preset: string; // keep this generic, as we'll be adding more presets in the future and this is only in a read capacity
+    };
 /**
  * Metadata about an existing index.
  *
@@ -8036,56 +8954,57 @@ type VectorizeIndexConfig = {
  * See {@link VectorizeIndexInfo} for its post-beta equivalent.
  */
 interface VectorizeIndexDetails {
-    /** The unique ID of the index */
-    readonly id: string;
-    /** The name of the index. */
-    name: string;
-    /** (optional) A human readable description for the index. */
-    description?: string;
-    /** The index configuration, including the dimension size and distance metric. */
-    config: VectorizeIndexConfig;
-    /** The number of records containing vectors within the index. */
-    vectorsCount: number;
+  /** The unique ID of the index */
+  readonly id: string;
+  /** The name of the index. */
+  name: string;
+  /** (optional) A human readable description for the index. */
+  description?: string;
+  /** The index configuration, including the dimension size and distance metric. */
+  config: VectorizeIndexConfig;
+  /** The number of records containing vectors within the index. */
+  vectorsCount: number;
 }
 /**
  * Metadata about an existing index.
  */
 interface VectorizeIndexInfo {
-    /** The number of records containing vectors within the index. */
-    vectorCount: number;
-    /** Number of dimensions the index has been configured for. */
-    dimensions: number;
-    /** ISO 8601 datetime of the last processed mutation on in the index. All changes before this mutation will be reflected in the index state. */
-    processedUpToDatetime: number;
-    /** UUIDv4 of the last mutation processed by the index. All changes before this mutation will be reflected in the index state. */
-    processedUpToMutation: number;
+  /** The number of records containing vectors within the index. */
+  vectorCount: number;
+  /** Number of dimensions the index has been configured for. */
+  dimensions: number;
+  /** ISO 8601 datetime of the last processed mutation on in the index. All changes before this mutation will be reflected in the index state. */
+  processedUpToDatetime: number;
+  /** UUIDv4 of the last mutation processed by the index. All changes before this mutation will be reflected in the index state. */
+  processedUpToMutation: number;
 }
 /**
  * Represents a single vector value set along with its associated metadata.
  */
 interface VectorizeVector {
-    /** The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents. */
-    id: string;
-    /** The vector values */
-    values: VectorFloatArray | number[];
-    /** The namespace this vector belongs to. */
-    namespace?: string;
-    /** Metadata associated with the vector. Includes the values of other fields and potentially additional details. */
-    metadata?: Record<string, VectorizeVectorMetadata>;
+  /** The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents. */
+  id: string;
+  /** The vector values */
+  values: VectorFloatArray | number[];
+  /** The namespace this vector belongs to. */
+  namespace?: string;
+  /** Metadata associated with the vector. Includes the values of other fields and potentially additional details. */
+  metadata?: Record<string, VectorizeVectorMetadata>;
 }
 /**
  * Represents a matched vector for a query along with its score and (if specified) the matching vector information.
  */
-type VectorizeMatch = Pick<Partial<VectorizeVector>, "values"> & Omit<VectorizeVector, "values"> & {
+type VectorizeMatch = Pick<Partial<VectorizeVector>, "values"> &
+  Omit<VectorizeVector, "values"> & {
     /** The score or rank for similarity, when returned as a result */
     score: number;
-};
+  };
 /**
  * A set of matching {@link VectorizeMatch} for a particular query.
  */
 interface VectorizeMatches {
-    matches: VectorizeMatch[];
-    count: number;
+  matches: VectorizeMatch[];
+  count: number;
 }
 /**
  * Results of an operation that performed a mutation on a set of vectors.
@@ -8095,18 +9014,18 @@ interface VectorizeMatches {
  * See {@link VectorizeAsyncMutation} for its post-beta equivalent.
  */
 interface VectorizeVectorMutation {
-    /* List of ids of vectors that were successfully processed. */
-    ids: string[];
-    /* Total count of the number of processed vectors. */
-    count: number;
+  /* List of ids of vectors that were successfully processed. */
+  ids: string[];
+  /* Total count of the number of processed vectors. */
+  count: number;
 }
 /**
  * Result type indicating a mutation on the Vectorize Index.
  * Actual mutations are processed async where the `mutationId` is the unique identifier for the operation.
  */
 interface VectorizeAsyncMutation {
-    /** The unique identifier for the async mutation operation containing the changeset. */
-    mutationId: string;
+  /** The unique identifier for the async mutation operation containing the changeset. */
+  mutationId: string;
 }
 /**
  * A Vectorize Vector Search Index for querying vectors/embeddings.
@@ -8115,42 +9034,45 @@ interface VectorizeAsyncMutation {
  * See {@link Vectorize} for its new implementation.
  */
 declare abstract class VectorizeIndex {
-    /**
-     * Get information about the currently bound index.
-     * @returns A promise that resolves with information about the current index.
-     */
-    public describe(): Promise<VectorizeIndexDetails>;
-    /**
-     * Use the provided vector to perform a similarity search across the index.
-     * @param vector Input vector that will be used to drive the similarity search.
-     * @param options Configuration options to massage the returned data.
-     * @returns A promise that resolves with matched and scored vectors.
-     */
-    public query(vector: VectorFloatArray | number[], options?: VectorizeQueryOptions): Promise<VectorizeMatches>;
-    /**
-     * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
-     * @param vectors List of vectors that will be inserted.
-     * @returns A promise that resolves with the ids & count of records that were successfully processed.
-     */
-    public insert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
-    /**
-     * Upsert a list of vectors into the index dataset. If a provided id exists, it will be replaced with the new values.
-     * @param vectors List of vectors that will be upserted.
-     * @returns A promise that resolves with the ids & count of records that were successfully processed.
-     */
-    public upsert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
-    /**
-     * Delete a list of vectors with a matching id.
-     * @param ids List of vector ids that should be deleted.
-     * @returns A promise that resolves with the ids & count of records that were successfully processed (and thus deleted).
-     */
-    public deleteByIds(ids: string[]): Promise<VectorizeVectorMutation>;
-    /**
-     * Get a list of vectors with a matching id.
-     * @param ids List of vector ids that should be returned.
-     * @returns A promise that resolves with the raw unscored vectors matching the id set.
-     */
-    public getByIds(ids: string[]): Promise<VectorizeVector[]>;
+  /**
+   * Get information about the currently bound index.
+   * @returns A promise that resolves with information about the current index.
+   */
+  public describe(): Promise<VectorizeIndexDetails>;
+  /**
+   * Use the provided vector to perform a similarity search across the index.
+   * @param vector Input vector that will be used to drive the similarity search.
+   * @param options Configuration options to massage the returned data.
+   * @returns A promise that resolves with matched and scored vectors.
+   */
+  public query(
+    vector: VectorFloatArray | number[],
+    options?: VectorizeQueryOptions,
+  ): Promise<VectorizeMatches>;
+  /**
+   * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
+   * @param vectors List of vectors that will be inserted.
+   * @returns A promise that resolves with the ids & count of records that were successfully processed.
+   */
+  public insert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
+  /**
+   * Upsert a list of vectors into the index dataset. If a provided id exists, it will be replaced with the new values.
+   * @param vectors List of vectors that will be upserted.
+   * @returns A promise that resolves with the ids & count of records that were successfully processed.
+   */
+  public upsert(vectors: VectorizeVector[]): Promise<VectorizeVectorMutation>;
+  /**
+   * Delete a list of vectors with a matching id.
+   * @param ids List of vector ids that should be deleted.
+   * @returns A promise that resolves with the ids & count of records that were successfully processed (and thus deleted).
+   */
+  public deleteByIds(ids: string[]): Promise<VectorizeVectorMutation>;
+  /**
+   * Get a list of vectors with a matching id.
+   * @param ids List of vector ids that should be returned.
+   * @returns A promise that resolves with the raw unscored vectors matching the id set.
+   */
+  public getByIds(ids: string[]): Promise<VectorizeVector[]>;
 }
 /**
  * A Vectorize Vector Search Index for querying vectors/embeddings.
@@ -8158,187 +9080,196 @@ declare abstract class VectorizeIndex {
  * Mutations in this version are async, returning a mutation id.
  */
 declare abstract class Vectorize {
-    /**
-     * Get information about the currently bound index.
-     * @returns A promise that resolves with information about the current index.
-     */
-    public describe(): Promise<VectorizeIndexInfo>;
-    /**
-     * Use the provided vector to perform a similarity search across the index.
-     * @param vector Input vector that will be used to drive the similarity search.
-     * @param options Configuration options to massage the returned data.
-     * @returns A promise that resolves with matched and scored vectors.
-     */
-    public query(vector: VectorFloatArray | number[], options?: VectorizeQueryOptions): Promise<VectorizeMatches>;
-    /**
-     * Use the provided vector-id to perform a similarity search across the index.
-     * @param vectorId Id for a vector in the index against which the index should be queried.
-     * @param options Configuration options to massage the returned data.
-     * @returns A promise that resolves with matched and scored vectors.
-     */
-    public queryById(vectorId: string, options?: VectorizeQueryOptions): Promise<VectorizeMatches>;
-    /**
-     * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
-     * @param vectors List of vectors that will be inserted.
-     * @returns A promise that resolves with a unique identifier of a mutation containing the insert changeset.
-     */
-    public insert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
-    /**
-     * Upsert a list of vectors into the index dataset. If a provided id exists, it will be replaced with the new values.
-     * @param vectors List of vectors that will be upserted.
-     * @returns A promise that resolves with a unique identifier of a mutation containing the upsert changeset.
-     */
-    public upsert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
-    /**
-     * Delete a list of vectors with a matching id.
-     * @param ids List of vector ids that should be deleted.
-     * @returns A promise that resolves with a unique identifier of a mutation containing the delete changeset.
-     */
-    public deleteByIds(ids: string[]): Promise<VectorizeAsyncMutation>;
-    /**
-     * Get a list of vectors with a matching id.
-     * @param ids List of vector ids that should be returned.
-     * @returns A promise that resolves with the raw unscored vectors matching the id set.
-     */
-    public getByIds(ids: string[]): Promise<VectorizeVector[]>;
+  /**
+   * Get information about the currently bound index.
+   * @returns A promise that resolves with information about the current index.
+   */
+  public describe(): Promise<VectorizeIndexInfo>;
+  /**
+   * Use the provided vector to perform a similarity search across the index.
+   * @param vector Input vector that will be used to drive the similarity search.
+   * @param options Configuration options to massage the returned data.
+   * @returns A promise that resolves with matched and scored vectors.
+   */
+  public query(
+    vector: VectorFloatArray | number[],
+    options?: VectorizeQueryOptions,
+  ): Promise<VectorizeMatches>;
+  /**
+   * Use the provided vector-id to perform a similarity search across the index.
+   * @param vectorId Id for a vector in the index against which the index should be queried.
+   * @param options Configuration options to massage the returned data.
+   * @returns A promise that resolves with matched and scored vectors.
+   */
+  public queryById(vectorId: string, options?: VectorizeQueryOptions): Promise<VectorizeMatches>;
+  /**
+   * Insert a list of vectors into the index dataset. If a provided id exists, an error will be thrown.
+   * @param vectors List of vectors that will be inserted.
+   * @returns A promise that resolves with a unique identifier of a mutation containing the insert changeset.
+   */
+  public insert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
+  /**
+   * Upsert a list of vectors into the index dataset. If a provided id exists, it will be replaced with the new values.
+   * @param vectors List of vectors that will be upserted.
+   * @returns A promise that resolves with a unique identifier of a mutation containing the upsert changeset.
+   */
+  public upsert(vectors: VectorizeVector[]): Promise<VectorizeAsyncMutation>;
+  /**
+   * Delete a list of vectors with a matching id.
+   * @param ids List of vector ids that should be deleted.
+   * @returns A promise that resolves with a unique identifier of a mutation containing the delete changeset.
+   */
+  public deleteByIds(ids: string[]): Promise<VectorizeAsyncMutation>;
+  /**
+   * Get a list of vectors with a matching id.
+   * @param ids List of vector ids that should be returned.
+   * @returns A promise that resolves with the raw unscored vectors matching the id set.
+   */
+  public getByIds(ids: string[]): Promise<VectorizeVector[]>;
 }
 /**
  * The interface for "version_metadata" binding
  * providing metadata about the Worker Version using this binding.
  */
 type WorkerVersionMetadata = {
-    /** The ID of the Worker Version using this binding */
-    id: string;
-    /** The tag of the Worker Version using this binding */
-    tag: string;
-    /** The timestamp of when the Worker Version was uploaded */
-    timestamp: string;
+  /** The ID of the Worker Version using this binding */
+  id: string;
+  /** The tag of the Worker Version using this binding */
+  tag: string;
+  /** The timestamp of when the Worker Version was uploaded */
+  timestamp: string;
 };
 interface DynamicDispatchLimits {
-    /**
-     * Limit CPU time in milliseconds.
-     */
-    cpuMs?: number;
-    /**
-     * Limit number of subrequests.
-     */
-    subRequests?: number;
+  /**
+   * Limit CPU time in milliseconds.
+   */
+  cpuMs?: number;
+  /**
+   * Limit number of subrequests.
+   */
+  subRequests?: number;
 }
 interface DynamicDispatchOptions {
-    /**
-     * Limit resources of invoked Worker script.
-     */
-    limits?: DynamicDispatchLimits;
-    /**
-     * Arguments for outbound Worker script, if configured.
-     */
-    outbound?: {
-        [key: string]: any;
-    };
+  /**
+   * Limit resources of invoked Worker script.
+   */
+  limits?: DynamicDispatchLimits;
+  /**
+   * Arguments for outbound Worker script, if configured.
+   */
+  outbound?: {
+    [key: string]: any;
+  };
 }
 interface DispatchNamespace {
-    /**
-    * @param name Name of the Worker script.
-    * @param args Arguments to Worker script.
-    * @param options Options for Dynamic Dispatch invocation.
-    * @returns A Fetcher object that allows you to send requests to the Worker script.
-    * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
-    */
-    get(name: string, args?: {
-        [key: string]: any;
-    }, options?: DynamicDispatchOptions): Fetcher;
+  /**
+   * @param name Name of the Worker script.
+   * @param args Arguments to Worker script.
+   * @param options Options for Dynamic Dispatch invocation.
+   * @returns A Fetcher object that allows you to send requests to the Worker script.
+   * @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown.
+   */
+  get(
+    name: string,
+    args?: {
+      [key: string]: any;
+    },
+    options?: DynamicDispatchOptions,
+  ): Fetcher;
 }
-declare module 'cloudflare:workflows' {
-    /**
-     * NonRetryableError allows for a user to throw a fatal error
-     * that makes a Workflow instance fail immediately without triggering a retry
-     */
-    export class NonRetryableError extends Error {
-        public constructor(message: string, name?: string);
-    }
+declare module "cloudflare:workflows" {
+  /**
+   * NonRetryableError allows for a user to throw a fatal error
+   * that makes a Workflow instance fail immediately without triggering a retry
+   */
+  export class NonRetryableError extends Error {
+    public constructor(message: string, name?: string);
+  }
 }
 declare abstract class Workflow<PARAMS = unknown> {
-    /**
-     * Get a handle to an existing instance of the Workflow.
-     * @param id Id for the instance of this Workflow
-     * @returns A promise that resolves with a handle for the Instance
-     */
-    public get(id: string): Promise<WorkflowInstance>;
-    /**
-     * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
-     * @param options Options when creating an instance including id and params
-     * @returns A promise that resolves with a handle for the Instance
-     */
-    public create(options?: WorkflowInstanceCreateOptions<PARAMS>): Promise<WorkflowInstance>;
-    /**
-     * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
-     * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
-     * @param batch List of Options when creating an instance including name and params
-     * @returns A promise that resolves with a list of handles for the created instances.
-     */
-    public createBatch(batch: WorkflowInstanceCreateOptions<PARAMS>[]): Promise<WorkflowInstance[]>;
+  /**
+   * Get a handle to an existing instance of the Workflow.
+   * @param id Id for the instance of this Workflow
+   * @returns A promise that resolves with a handle for the Instance
+   */
+  public get(id: string): Promise<WorkflowInstance>;
+  /**
+   * Create a new instance and return a handle to it. If a provided id exists, an error will be thrown.
+   * @param options Options when creating an instance including id and params
+   * @returns A promise that resolves with a handle for the Instance
+   */
+  public create(options?: WorkflowInstanceCreateOptions<PARAMS>): Promise<WorkflowInstance>;
+  /**
+   * Create a batch of instances and return handle for all of them. If a provided id exists, an error will be thrown.
+   * `createBatch` is limited at 100 instances at a time or when the RPC limit for the batch (1MiB) is reached.
+   * @param batch List of Options when creating an instance including name and params
+   * @returns A promise that resolves with a list of handles for the created instances.
+   */
+  public createBatch(batch: WorkflowInstanceCreateOptions<PARAMS>[]): Promise<WorkflowInstance[]>;
 }
-type WorkflowDurationLabel = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
-type WorkflowSleepDuration = `${number} ${WorkflowDurationLabel}${'s' | ''}` | number;
+type WorkflowDurationLabel = "second" | "minute" | "hour" | "day" | "week" | "month" | "year";
+type WorkflowSleepDuration = `${number} ${WorkflowDurationLabel}${"s" | ""}` | number;
 type WorkflowRetentionDuration = WorkflowSleepDuration;
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
-    /**
-     * An id for your Workflow instance. Must be unique within the Workflow.
-     */
-    id?: string;
-    /**
-     * The event payload the Workflow instance is triggered with
-     */
-    params?: PARAMS;
-    /**
-     * The retention policy for Workflow instance.
-     * Defaults to the maximum retention period available for the owner's account.
-     */
-    retention?: {
-        successRetention?: WorkflowRetentionDuration;
-        errorRetention?: WorkflowRetentionDuration;
-    };
+  /**
+   * An id for your Workflow instance. Must be unique within the Workflow.
+   */
+  id?: string;
+  /**
+   * The event payload the Workflow instance is triggered with
+   */
+  params?: PARAMS;
+  /**
+   * The retention policy for Workflow instance.
+   * Defaults to the maximum retention period available for the owner's account.
+   */
+  retention?: {
+    successRetention?: WorkflowRetentionDuration;
+    errorRetention?: WorkflowRetentionDuration;
+  };
 }
 type InstanceStatus = {
-    status: 'queued' // means that instance is waiting to be started (see concurrency limits)
-     | 'running' | 'paused' | 'errored' | 'terminated' // user terminated the instance while it was running
-     | 'complete' | 'waiting' // instance is hibernating and waiting for sleep or event to finish
-     | 'waitingForPause' // instance is finishing the current work to pause
-     | 'unknown';
-    error?: string;
-    output?: object;
+  status:
+    | "queued" // means that instance is waiting to be started (see concurrency limits)
+    | "running"
+    | "paused"
+    | "errored"
+    | "terminated" // user terminated the instance while it was running
+    | "complete"
+    | "waiting" // instance is hibernating and waiting for sleep or event to finish
+    | "waitingForPause" // instance is finishing the current work to pause
+    | "unknown";
+  error?: string;
+  output?: object;
 };
 interface WorkflowError {
-    code?: number;
-    message: string;
+  code?: number;
+  message: string;
 }
 declare abstract class WorkflowInstance {
-    public id: string;
-    /**
-     * Pause the instance.
-     */
-    public pause(): Promise<void>;
-    /**
-     * Resume the instance. If it is already running, an error will be thrown.
-     */
-    public resume(): Promise<void>;
-    /**
-     * Terminate the instance. If it is errored, terminated or complete, an error will be thrown.
-     */
-    public terminate(): Promise<void>;
-    /**
-     * Restart the instance.
-     */
-    public restart(): Promise<void>;
-    /**
-     * Returns the current status of the instance.
-     */
-    public status(): Promise<InstanceStatus>;
-    /**
-     * Send an event to this instance.
-     */
-    public sendEvent({ type, payload, }: {
-        type: string;
-        payload: unknown;
-    }): Promise<void>;
+  public id: string;
+  /**
+   * Pause the instance.
+   */
+  public pause(): Promise<void>;
+  /**
+   * Resume the instance. If it is already running, an error will be thrown.
+   */
+  public resume(): Promise<void>;
+  /**
+   * Terminate the instance. If it is errored, terminated or complete, an error will be thrown.
+   */
+  public terminate(): Promise<void>;
+  /**
+   * Restart the instance.
+   */
+  public restart(): Promise<void>;
+  /**
+   * Returns the current status of the instance.
+   */
+  public status(): Promise<InstanceStatus>;
+  /**
+   * Send an event to this instance.
+   */
+  public sendEvent({ type, payload }: { type: string; payload: unknown }): Promise<void>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "resend": "^6.1.2",
         "tailwind-merge": "^2.5.5"
       },
       "devDependencies": {
@@ -23848,6 +23849,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.1.2.tgz",
+      "integrity": "sha512-C9Q+YkRe57P8MQlkHG3yatSR/B6sqBGA06Ri2DveJfkz9Vm16182FC/iHB0K6IAfmqZ4yRrFebFw1EPuktLtSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "resend": "^6.1.2",
     "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {

--- a/src/emails/verification-email.tsx
+++ b/src/emails/verification-email.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable @next/next/no-head-element */
+
+import type { CSSProperties } from "react";
+
+const DEFAULT_APP_NAME = "Cloudflare Next Starter";
+const DEFAULT_PRIMARY_COLOR = "#2563eb";
+const DEFAULT_TEXT_COLOR = "#0f172a";
+
+export interface VerificationEmailProps {
+  recipientName: string;
+  verificationUrl: string;
+  appName?: string;
+  primaryColor?: string;
+}
+
+const bodyStyle: CSSProperties = {
+  fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  lineHeight: 1.5,
+  color: DEFAULT_TEXT_COLOR,
+  margin: 0,
+  padding: "32px 24px",
+  backgroundColor: "#f8fafc",
+};
+
+const cardStyle: CSSProperties = {
+  margin: "0 auto",
+  maxWidth: 480,
+  padding: "32px 28px",
+  backgroundColor: "#ffffff",
+  borderRadius: 12,
+  boxShadow: "0 12px 35px rgba(15, 23, 42, 0.08)",
+};
+
+const buttonStyle: CSSProperties = {
+  display: "inline-block",
+  padding: "12px 20px",
+  borderRadius: 8,
+  fontWeight: 600,
+  fontSize: 16,
+  color: "#ffffff",
+  textDecoration: "none",
+};
+
+const footerStyle: CSSProperties = {
+  marginTop: 32,
+  fontSize: 12,
+  color: "#64748b",
+};
+
+export function VerificationEmail({
+  recipientName,
+  verificationUrl,
+  appName = DEFAULT_APP_NAME,
+  primaryColor = DEFAULT_PRIMARY_COLOR,
+}: VerificationEmailProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <title>{`Verify your email address | ${appName}`}</title>
+      </head>
+      <body style={bodyStyle}>
+        <table role="presentation" width="100%" cellPadding={0} cellSpacing={0}>
+          <tbody>
+            <tr>
+              <td align="center">
+                <div style={cardStyle}>
+                  <p style={{ fontSize: 18, margin: "0 0 12px" }}>Hi {recipientName},</p>
+                  <p style={{ margin: "0 0 16px" }}>
+                    Thanks for signing up for <strong>{appName}</strong>. Please confirm your email
+                    address to finish creating your account.
+                  </p>
+                  <p style={{ margin: "24px 0" }}>
+                    <a
+                      href={verificationUrl}
+                      style={{ ...buttonStyle, backgroundColor: primaryColor }}
+                    >
+                      Verify email address
+                    </a>
+                  </p>
+                  <p style={{ margin: "0 0 16px" }}>
+                    If the button above does not work, copy and paste this link into your browser:
+                  </p>
+                  <p style={{ margin: "0 0 16px" }}>
+                    <a href={verificationUrl} style={{ color: primaryColor }}>
+                      {verificationUrl}
+                    </a>
+                  </p>
+                  <p style={{ margin: 0 }}>
+                    If you did not create this account you can safely ignore this email.
+                  </p>
+                  <p style={footerStyle}>Sent with ❤️ by {appName}</p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </body>
+    </html>
+  );
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,3 +1,26 @@
 import { createAuthClient } from "better-auth/react";
 
-export const authClient = createAuthClient({});
+import { sharedBetterAuthOptions } from "./auth-options";
+
+type AuthClientOptions = {
+  $InferAuth: typeof sharedBetterAuthOptions;
+};
+
+const baseAuthClient = createAuthClient<AuthClientOptions>({
+  $InferAuth: sharedBetterAuthOptions,
+});
+
+type BaseAuthClient = typeof baseAuthClient;
+
+type VerificationResult = Awaited<ReturnType<BaseAuthClient["signIn"]["email"]>>;
+
+type ExtendedAuthClient = BaseAuthClient & {
+  emailVerification: {
+    sendVerificationEmail: (data: {
+      email: string;
+      callbackURL?: string;
+    }) => Promise<VerificationResult>;
+  };
+};
+
+export const authClient = baseAuthClient as ExtendedAuthClient;

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -1,0 +1,12 @@
+import type { BetterAuthOptions } from "better-auth";
+
+export const sharedBetterAuthOptions = {
+  emailAndPassword: {
+    enabled: true,
+    requireEmailVerification: true,
+  },
+  emailVerification: {
+    sendOnSignUp: true,
+  },
+  trustedOrigins: ["http://localhost:8787", "*.workers.dev", "*.cwllll.com"],
+} satisfies BetterAuthOptions;

--- a/src/lib/resend.tsx
+++ b/src/lib/resend.tsx
@@ -1,0 +1,100 @@
+import type { ReactElement } from "react";
+import { Resend } from "resend";
+
+import { VerificationEmail } from "@/emails/verification-email";
+
+const DEFAULT_FROM_NAME = "Cloudflare Next Starter";
+
+interface MailRecipient {
+  email: string;
+  name?: string | null;
+}
+
+interface MailContent {
+  to: MailRecipient;
+  subject: string;
+  text?: string;
+  html?: string;
+  react?: ReactElement;
+  replyTo?: MailRecipient;
+}
+
+function ensureResendApiKey(env: CloudflareEnv): string {
+  const apiKey = env.RESEND_API_KEY;
+
+  if (!apiKey) {
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+
+  return apiKey;
+}
+
+function resolveSender(env: CloudflareEnv): MailRecipient {
+  const email = env.RESEND_FROM_EMAIL;
+
+  if (!email) {
+    throw new Error("RESEND_FROM_EMAIL is not configured");
+  }
+
+  return {
+    email,
+    name: env.RESEND_FROM_NAME ?? DEFAULT_FROM_NAME,
+  };
+}
+
+function formatRecipient(recipient: MailRecipient): string {
+  const { email, name } = recipient;
+
+  if (!name || !name.trim() || name.trim() === email) {
+    return email;
+  }
+
+  return `${name.trim()} <${email}>`;
+}
+
+async function sendMail(env: CloudflareEnv, message: MailContent) {
+  const resend = new Resend(ensureResendApiKey(env));
+  const from = resolveSender(env);
+  const replyTo = message.replyTo ?? from;
+
+  const { error } = await resend.emails.send({
+    from: formatRecipient(from),
+    to: [formatRecipient(message.to)],
+    subject: message.subject,
+    text: message.text,
+    html: message.html,
+    react: message.react,
+    replyTo: formatRecipient(replyTo),
+  });
+
+  if (error) {
+    throw new Error(`Resend request failed (${error.name}): ${error.message}`);
+  }
+}
+
+export async function deliverVerificationEmail(
+  env: CloudflareEnv,
+  options: { to: MailRecipient; verificationUrl: string },
+) {
+  const { to, verificationUrl } = options;
+  const safeName = to.name?.trim() || to.email;
+
+  const subject = "Verify your email address";
+  const text = [
+    `Hi ${safeName},`,
+    "",
+    "Thanks for signing up for Cloudflare Next Starter.",
+    "Please confirm your email address by opening the link below:",
+    "",
+    verificationUrl,
+    "",
+    "If you did not create this account you can safely ignore this email.",
+  ].join("\n");
+
+  await sendMail(env, {
+    to,
+    subject,
+    text,
+    react: <VerificationEmail recipientName={safeName} verificationUrl={verificationUrl} />,
+  });
+}

--- a/src/stories/emails/VerificationEmail.stories.tsx
+++ b/src/stories/emails/VerificationEmail.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { VerificationEmail } from "@/emails/verification-email";
+
+const meta = {
+  title: "Emails/VerificationEmail",
+  component: VerificationEmail,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    recipientName: "Ada Lovelace",
+    verificationUrl: "https://example.com/verify?code=123456",
+  },
+} satisfies Meta<typeof VerificationEmail>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,6 +29,10 @@
       "id": "418b43fc589842d088cc79d412a12222"
     }
   ],
+  "vars": {
+    "RESEND_FROM_EMAIL": "login@example.com",
+    "RESEND_FROM_NAME": "Cloudflare Next Starter"
+  },
   "d1_databases": [
     {
       "binding": "D1",


### PR DESCRIPTION
## Summary
- centralize shared Better Auth options so the client and server stay in sync on verification behavior
- extend the React auth client typing to expose the email verification API used by the status card
- fix the Resend helper to use the correct replyTo casing when sending verification email requests

## Testing
- npm run lint
- npm run cf:build

------
https://chatgpt.com/codex/tasks/task_e_68e3d9f06910832d86e600db4c6ca124