### PR TITLE
chore: stabilize test ci setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:ci": "npm-run-all --parallel test:ci:vitest test:ci:playwright",
+    "test:ci": "npm-run-all test:ci:setup --parallel test:ci:vitest test:ci:playwright",
     "test:ci:vitest": "vitest run --coverage --reporter=default --reporter=junit --outputFile=reports/vitest-junit.xml",
-    "pretest:ci:playwright": "node -e \"require('fs').mkdirSync('reports/playwright', { recursive: true });\"",
-    "test:ci:playwright": "PLAYWRIGHT_JUNIT_OUTPUT_NAME=reports/playwright/results.xml playwright test",
+    "test:ci:playwright": "node -e \"require('fs').mkdirSync('reports/playwright', { recursive: true });\" && PLAYWRIGHT_JUNIT_OUTPUT_NAME=reports/playwright/results.xml playwright test",
     "test:playwright": "playwright test",
     "prepare": "lefthook install",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "commit": "cz"
+    "commit": "cz",
+    "test:ci:setup": "node ./scripts/prepare-playwright.mjs"
   },
   "dependencies": {
     "@libsql/client": "^0.15.15",

--- a/scripts/prepare-playwright.mjs
+++ b/scripts/prepare-playwright.mjs
@@ -1,0 +1,23 @@
+import { mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+
+mkdirSync(path.join('reports', 'playwright'), { recursive: true });
+
+const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const args = ['playwright', 'install', 'chromium'];
+
+if (process.platform === 'linux') {
+  args.push('--with-deps');
+}
+
+const result = spawnSync(npxCommand, args, { stdio: 'inherit' });
+
+if (result.error) {
+  throw result.error;
+}
+
+if (typeof result.status === 'number' && result.status !== 0) {
+  process.exit(result.status);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,7 @@ import { defineConfig } from 'vitest/config';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 
-const dirname =
-  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 const isCI = process.env.CI === 'true';
 
@@ -14,6 +13,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(dirname, 'src'),
+      '@react-email/render': path.resolve(dirname, 'node_modules/@react-email/render/dist/node/index.mjs'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- ensure Playwright browsers are installed before CI tests and reuse the installer script
- point Vitest to the Node build of `@react-email/render` to avoid missing module errors during coverage collection

## Testing
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68e49451ebbc832dae6786f6d248d483