### PR TITLE
feat: integrate Sentry observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Follow this path to fork the project, wire it into your Cloudflare account, and 
 
    Configure Better Auth by setting the `BETTER_AUTH_TRUSTED_ORIGINS` variable in `wrangler.jsonc` (or the Cloudflare dashboard) to a comma-separated list of allowed domains. The Worker falls back to `http://localhost:8787` and `*.workers.dev` when the variable is omitted, which keeps local development frictionless while still letting you tighten origins per environment.
 
+## Observability with Sentry
+
+- The Cloudflare Worker entry point (`worker/index.ts`) is wrapped with `@sentry/cloudflare`, so unhandled exceptions, spans, and optional request logs automatically flow into your Sentry project.
+- Provide the `SENTRY_DSN` variable (secret or plain var) in each environment you want to monitor. Optional tuning is available via `SENTRY_TRACES_SAMPLE_RATE` (float between 0 and 1) and `SENTRY_ENABLE_LOGS` (boolean string such as `true`, `false`, `1`, or `0`).
+- Wrangler is configured with the `CF_VERSION_METADATA` binding and source-map uploads so Sentry can tag events with the active Worker version and resolve stack traces.
+- Deployers can verify their setup by hitting `/api/debug-sentry`, which throws a test error inside a trace span to exercise the integration end-to-end.
+
 ## Automated Quality Gates
 
 GitHub Actions (`.github/workflows/test.yml`) guard every push and pull request:

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -10,6 +10,10 @@ declare namespace Cloudflare {
     R2: R2Bucket;
     D1: D1Database;
     ASSETS: Fetcher;
+    CF_VERSION_METADATA: WorkerVersionMetadata;
+    SENTRY_DSN?: string;
+    SENTRY_TRACES_SAMPLE_RATE?: string;
+    SENTRY_ENABLE_LOGS?: string;
   }
 }
 interface CloudflareEnv extends Cloudflare.Env {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@opennextjs/cloudflare": "^1.3.0",
         "@react-email/components": "^0.5.6",
         "@react-email/render": "^1.3.2",
+        "@sentry/cloudflare": "^10.17.0",
         "better-auth": "^1.3.26",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -11280,6 +11281,15 @@
         "wrangler": "^4.38.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@peculiar/asn1-android": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.5.0.tgz",
@@ -12139,6 +12149,36 @@
       },
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@sentry/cloudflare": {
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.17.0.tgz",
+      "integrity": "sha512-99ZITwImTbIkMNQReJQs0NqXvOIX/AgNie9pjWnPeLqTiv5jji0ZMnXyd5YSS58iuqqnDqETnbomoFjpvh/ufA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@sentry/core": "10.17.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.17.0.tgz",
+      "integrity": "sha512-UVIvxSzS0n5QbIDPyFf0WX9I77Of1bcr6a0sCEKfjhJGmGQ8mFWoWgR2gF4wcPw60XUrzbryCr79eOsIHLQ5cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@simplewebauthn/browser": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@opennextjs/cloudflare": "^1.3.0",
     "@react-email/components": "^0.5.6",
     "@react-email/render": "^1.3.2",
+    "@sentry/cloudflare": "^10.17.0",
     "better-auth": "^1.3.26",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/app/api/debug-sentry/route.ts
+++ b/src/app/api/debug-sentry/route.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/cloudflare';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  await Sentry.startSpan(
+    {
+      op: 'debug',
+      name: 'Sentry debug endpoint',
+    },
+    async () => {
+      throw new Error('Sentry debug endpoint triggered');
+    },
+  );
+
+  return new Response('', { status: 204 });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "./cloudflare-env.secrets.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]

--- a/types/open-next-worker.d.ts
+++ b/types/open-next-worker.d.ts
@@ -1,0 +1,4 @@
+declare module '../.open-next/worker' {
+  const worker: ExportedHandler<CloudflareEnv>;
+  export default worker;
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,49 @@
+import * as Sentry from '@sentry/cloudflare';
+import worker from '../.open-next/worker';
+
+type Env = CloudflareEnv & {
+  CF_VERSION_METADATA: WorkerVersionMetadata;
+  SENTRY_DSN?: string;
+  SENTRY_TRACES_SAMPLE_RATE?: string;
+  SENTRY_ENABLE_LOGS?: string;
+};
+
+const truthyValues = new Set(['1', 'true', 'yes', 'on']);
+const falsyValues = new Set(['0', 'false', 'no', 'off']);
+
+const parseBoolean = (value?: string) => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (truthyValues.has(normalized)) {
+    return true;
+  }
+  if (falsyValues.has(normalized)) {
+    return false;
+  }
+
+  return undefined;
+};
+
+const parseNumber = (value?: string) => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export default Sentry.withSentry((env: Env) => {
+  const tracesSampleRate = parseNumber(env.SENTRY_TRACES_SAMPLE_RATE);
+  const enableLogs = parseBoolean(env.SENTRY_ENABLE_LOGS);
+
+  return {
+    dsn: env.SENTRY_DSN,
+    release: env.CF_VERSION_METADATA?.id,
+    tracesSampleRate,
+    enableLogs: enableLogs ?? false,
+  };
+}, worker);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,13 +5,18 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "cf-next-starter",
-  "main": ".open-next/worker.js",
+  "main": "worker/index.ts",
   "compatibility_date": "2025-03-01",
   "compatibility_flags": [
     "nodejs_compat",
-    "global_fetch_strictly_public"
+    "global_fetch_strictly_public",
+    "nodejs_als"
   ],
   "workers_dev": true,
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
+  "upload_source_maps": true,
   "preview_urls": true,
   "assets": {
     "binding": "ASSETS",
@@ -47,6 +52,9 @@
   },
   "env": {
     "preview": {
+      "version_metadata": {
+        "binding": "CF_VERSION_METADATA"
+      },
       "r2_buckets": [
         {
           "binding": "R2",


### PR DESCRIPTION
## Summary
- wrap the generated OpenNext worker with @sentry/cloudflare so DSN, release metadata, tracing, and optional log forwarding are configured from bindings
- update Cloudflare and TypeScript configs to expose the CF_VERSION_METADATA binding and generated worker types for the new entry point
- document the Sentry setup and add a /api/debug-sentry route that triggers a span-wrapped test error for verification

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4cdd8fd8c832da24b1aec3c554ba5