### PR TITLE
chore: harden sentry config for cloudflare

### DIFF
--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -7,6 +7,7 @@ declare namespace Cloudflare {
     DEFAULT_EMAIL_FROM_ADDRESS: 'noreply@cwllll.com';
     DEFAULT_EMAIL_FROM_NAME: 'Cloudflare Next Starter';
     BETTER_AUTH_TRUSTED_ORIGINS: 'http://localhost:8787,*.workers.dev,*.cwllll.com';
+    SENTRY_DSN: string;
     R2: R2Bucket;
     D1: D1Database;
     ASSETS: Fetcher;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,9 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN ?? '',
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/sentry.config.shared.ts
+++ b/sentry.config.shared.ts
@@ -1,0 +1,55 @@
+export type SentryBaseConfig = {
+  dsn?: string;
+  enabled: boolean;
+  tracesSampleRate: number;
+  enableLogs: boolean;
+  debug: boolean;
+};
+
+declare global {
+  var __SENTRY_DSN__: string | undefined;
+}
+
+function setGlobalDsn(value?: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+
+  if (typeof globalThis !== 'undefined') {
+    globalThis.__SENTRY_DSN__ = value;
+  }
+
+  return true;
+}
+
+export function primeSentryDsn(value?: string | null): void {
+  if (globalThis.__SENTRY_DSN__) {
+    return;
+  }
+
+  setGlobalDsn(value);
+}
+
+export function resolveSentryDsn(): string | undefined {
+  if (typeof globalThis !== 'undefined' && globalThis.__SENTRY_DSN__) {
+    return globalThis.__SENTRY_DSN__;
+  }
+
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN ?? undefined;
+  }
+
+  return undefined;
+}
+
+export function createBaseSentryConfig(): SentryBaseConfig {
+  const dsn = resolveSentryDsn();
+
+  return {
+    dsn,
+    enabled: Boolean(dsn),
+    tracesSampleRate: 1,
+    enableLogs: true,
+    debug: false,
+  };
+}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,15 +5,8 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { createBaseSentryConfig } from './sentry.config.shared';
+
 Sentry.init({
-  dsn: 'https://6050c1828d925b3aed83e86f7b2d52d7@o4509060729470976.ingest.us.sentry.io/4510147471802368',
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
+  ...createBaseSentryConfig(),
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,15 +4,8 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { createBaseSentryConfig } from './sentry.config.shared';
+
 Sentry.init({
-  dsn: 'https://6050c1828d925b3aed83e86f7b2d52d7@o4509060729470976.ingest.us.sentry.io/4510147471802368',
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
+  ...createBaseSentryConfig(),
 });

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -4,16 +4,13 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { createBaseSentryConfig } from '../sentry.config.shared';
+
 Sentry.init({
-  dsn: 'https://6050c1828d925b3aed83e86f7b2d52d7@o4509060729470976.ingest.us.sentry.io/4510147471802368',
+  ...createBaseSentryConfig(),
 
   // Add optional integrations for additional features
   integrations: [Sentry.replayIntegration()],
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
@@ -22,9 +19,6 @@ Sentry.init({
 
   // Define how likely Replay events are sampled when an error occurs.
   replaysOnErrorSampleRate: 1.0,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,26 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
 import * as Sentry from '@sentry/nextjs';
 
+import { primeSentryDsn } from '../sentry.config.shared';
+
+async function ensureSentryDsn() {
+  primeSentryDsn(process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN);
+
+  if (globalThis.__SENTRY_DSN__) {
+    return;
+  }
+
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    primeSentryDsn(env?.SENTRY_DSN);
+  } catch {
+    // No Cloudflare context is available during build-time or local scripts.
+  }
+}
+
 export async function register() {
+  await ensureSentryDsn();
+
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('../sentry.server.config');
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -44,7 +44,8 @@
   "vars": {
     "DEFAULT_EMAIL_FROM_ADDRESS": "noreply@cwllll.com",
     "DEFAULT_EMAIL_FROM_NAME": "Cloudflare Next Starter",
-    "BETTER_AUTH_TRUSTED_ORIGINS": "http://localhost:8787,*.workers.dev,*.cwllll.com"
+    "BETTER_AUTH_TRUSTED_ORIGINS": "http://localhost:8787,*.workers.dev,*.cwllll.com",
+    "SENTRY_DSN": "https://6050c1828d925b3aed83e86f7b2d52d7@o4509060729470976.ingest.us.sentry.io/4510147471802368"
   },
   "env": {
     "preview": {
@@ -71,7 +72,8 @@
       "vars": {
         "DEFAULT_EMAIL_FROM_ADDRESS": "noreply@cwllll.com",
         "DEFAULT_EMAIL_FROM_NAME": "Cloudflare Next Starter",
-        "BETTER_AUTH_TRUSTED_ORIGINS": "http://localhost:8787,*.workers.dev,*.cwllll.com"
+        "BETTER_AUTH_TRUSTED_ORIGINS": "http://localhost:8787,*.workers.dev,*.cwllll.com",
+        "SENTRY_DSN": "https://6050c1828d925b3aed83e86f7b2d52d7@o4509060729470976.ingest.us.sentry.io/4510147471802368"
       }
     }
   }


### PR DESCRIPTION
## Summary
- centralize Sentry initialization logic so the DSN can be supplied via environment variables
- prime the DSN from Cloudflare bindings before loading the server and edge runtimes
- expose the Sentry DSN through Next.js env wiring and Wrangler vars for worker deployments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f344f560832d95e9ec8fffa5aa61