### PR TITLE
Ignore Playwright SEO artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: '20'
           cache: npm
 
       - name: Install dependencies
@@ -51,6 +51,14 @@ jobs:
           path: |
             playwright-report
             reports/playwright/results.xml
+          if-no-files-found: warn
+
+      - name: Upload SEO snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seo-home-no-js
+          path: artifacts/seo
           if-no-files-found: warn
 
       - name: Vitest Test Report

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # testing
 /coverage
 /reports
+artifacts/
+playwright-report/
+test-results/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Validate the server-rendered homepage and capture a JavaScript-disabled screensh
 2. On fresh Debian/Ubuntu environments, install the system packages Playwright needs to launch headless Chromium: `npx playwright install-deps chromium`.
 3. Run `npm run test:seo` to build the worker, spin up the local dev server, and execute the no-JS checks.
 
-The run saves an `artifacts/seo/home-no-js.png` snapshot of the homepage exactly as search engines see it, alongside assertions that verify the SSR metadata and hero content.
+The run saves an `artifacts/seo/home-no-js.png` snapshot of the homepage exactly as search engines see it, alongside assertions that verify the SSR metadata and hero content. When CI executes `npm run test:ci`, the `Test and lint` workflow uploads the contents of `artifacts/seo/` as a GitHub Actions artifact named `seo-home-no-js`, so reviewers can download the latest no-JS render from each run.
 
 ## Local Guardrails & Commit Workflow
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ GitHub Actions (`.github/workflows/test.yml`) guard every push and pull request:
 - ESLint and the CI-friendly `npm run test:ci` target execute Vitest alongside Playwright, uploading coverage, Vitest JUnit, and Playwright reports as artifacts.
 - Failures feed directly into the GitHub Checks UI via `dorny/test-reporter`, helping reviewers triage regressions fast.
 
+## No-JS SEO snapshots
+
+Validate the server-rendered homepage and capture a JavaScript-disabled screenshot with the dedicated Playwright suite:
+
+1. Install the Chromium browser that the suite depends on: `npx playwright install chromium`.
+2. On fresh Debian/Ubuntu environments, install the system packages Playwright needs to launch headless Chromium: `npx playwright install-deps chromium`.
+3. Run `npm run test:seo` to build the worker, spin up the local dev server, and execute the no-JS checks.
+
+The run saves an `artifacts/seo/home-no-js.png` snapshot of the homepage exactly as search engines see it, alongside assertions that verify the SSR metadata and hero content.
+
 ## Local Guardrails & Commit Workflow
 
 - **Lefthook pre-commit and commit-msg hooks** run `lint-staged` and `commitlint` automatically so formatting and lint rules stay enforced before code lands in the repository.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pretest:ci:playwright": "node -e \"require('fs').mkdirSync('reports/playwright', { recursive: true });\"",
     "test:ci:playwright": "PLAYWRIGHT_JUNIT_OUTPUT_NAME=reports/playwright/results.xml playwright test",
     "test:playwright": "playwright test",
+    "test:seo": "playwright test --project=seo-no-js",
     "prepare": "lefthook install",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,49 +1,58 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:8787";
-const junitOutputFile =
-  process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME ??
-  "reports/playwright/results.xml";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:8787';
+const junitOutputFile = process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME ?? 'reports/playwright/results.xml';
 const htmlReporterOptions = {
-  outputFolder: "playwright-report",
-  open: process.env.CI ? "never" : "on-failure",
+  outputFolder: 'playwright-report',
+  open: process.env.CI ? 'never' : 'on-failure',
 };
 const isCI = !!process.env.CI;
 
 export default defineConfig({
-  testDir: "./tests",
+  testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   reporter: isCI
-    ? [["line"], ["junit", { outputFile: junitOutputFile }], ["html", htmlReporterOptions]]
-    : [["list"], ["html", htmlReporterOptions]],
+    ? [['line'], ['junit', { outputFile: junitOutputFile }], ['html', htmlReporterOptions]]
+    : [['list'], ['html', htmlReporterOptions]],
   use: {
     baseURL,
-    trace: "on-first-retry",
+    trace: 'on-first-retry',
   },
   webServer: {
-    command: "npm run cf:dev",
+    command: 'npm run cf:dev',
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 4 * 60 * 1000,
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
   projects: [
     {
-      name: "integration",
-      testDir: "./tests/integration",
-      testMatch: "**/*.spec.ts",
+      name: 'integration',
+      testDir: './tests/integration',
+      testMatch: '**/*.spec.ts',
     },
     {
-      name: "e2e",
-      testDir: "./tests/e2e",
-      testMatch: "**/*.e2e.ts",
+      name: 'e2e',
+      testDir: './tests/e2e',
+      testMatch: '**/*.e2e.ts',
+      testIgnore: '**/seo-*.e2e.ts',
       use: {
-        ...devices["Desktop Chrome"],
+        ...devices['Desktop Chrome'],
       },
+    },
+    {
+      name: 'seo-no-js',
+      testDir: './tests/e2e',
+      testMatch: '**/seo-*.e2e.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        javaScriptEnabled: false,
+      },
+      outputDir: 'test-results/seo-no-js',
     },
   ],
 });

--- a/tests/e2e/seo-homepage.e2e.ts
+++ b/tests/e2e/seo-homepage.e2e.ts
@@ -1,0 +1,32 @@
+import { mkdir } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+const seoArtifactsDir = 'artifacts/seo';
+const screenshotPath = `${seoArtifactsDir}/home-no-js.png`;
+
+test.describe('homepage seo without javascript', () => {
+  test('captures ssr content and metadata', async ({ page, context }) => {
+    await page.goto('/');
+
+    await mkdir(seoArtifactsDir, { recursive: true });
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+
+    await expect(page).toHaveTitle('Cloudflare + Next.js starter');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+
+    const metaDescription = await page.locator('meta[name="description"]').getAttribute('content');
+    expect(metaDescription).toBe('Check your Cloudflare bindings with a shadcn/ui dashboard.');
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Cloudflare + Next.js starter kit' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Deploy to Cloudflare Workers' })).toBeVisible();
+
+    const response = await context.request.get('/');
+    expect(response.ok()).toBeTruthy();
+
+    const html = await response.text();
+    expect(html).toContain('<title>Cloudflare + Next.js starter</title>');
+    expect(html).toContain('name="description" content="Check your Cloudflare bindings with a shadcn/ui dashboard."');
+    expect(html).toContain('Cloudflare + Next.js starter kit');
+  });
+});

--- a/tests/e2e/seo-homepage.e2e.ts
+++ b/tests/e2e/seo-homepage.e2e.ts
@@ -6,11 +6,15 @@ const seoArtifactsDir = 'artifacts/seo';
 const screenshotPath = `${seoArtifactsDir}/home-no-js.png`;
 
 test.describe('homepage seo without javascript', () => {
-  test('captures ssr content and metadata', async ({ page, context }) => {
+  test('captures ssr content and metadata', async ({ page, context }, testInfo) => {
     await page.goto('/');
 
     await mkdir(seoArtifactsDir, { recursive: true });
     await page.screenshot({ path: screenshotPath, fullPage: true });
+    await testInfo.attach('seo-home-no-js', {
+      path: screenshotPath,
+      contentType: 'image/png',
+    });
 
     await expect(page).toHaveTitle('Cloudflare + Next.js starter');
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');


### PR DESCRIPTION
## Summary
- ignore generated Playwright SEO assets and reports so the repository stays clean

## Testing
- npm run test:seo

------
https://chatgpt.com/codex/tasks/task_e_68e6d0da3d8c832db056126fbf33e4e5