### PR TITLE
feat: add Google sign-in to Better Auth demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,22 @@ Follow this path to fork the project, wire it into your Cloudflare account, and 
    # Update wrangler.jsonc with the generated IDs
    ```
 
-4. **Configure authentication secrets and email provider** – Generate a random `BETTER_AUTH_SECRET`, create a Resend API key, and register the default "from" identity used by transactional email.
+4. **Configure authentication secrets and email provider** – Generate a random `BETTER_AUTH_SECRET`, create a Resend API key, and register the default "from" identity used by transactional email. When enabling Google sign-in, also create an OAuth Client ID (Web application) in the Google Cloud Console and capture the client ID/secret.
 
    ```bash
    wrangler secret put BETTER_AUTH_SECRET
    wrangler secret put RESEND_API_KEY
+   wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_ID
+   wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_SECRET
    # for preview environment
    wrangler secret put BETTER_AUTH_SECRET --env preview
    wrangler secret put RESEND_API_KEY --env preview
+   wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_ID --env preview
+   wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_SECRET --env preview
    ```
 
    Update `DEFAULT_EMAIL_FROM_ADDRESS` and `DEFAULT_EMAIL_FROM_NAME` in `wrangler.jsonc` to match your verified sender.
+   For Google OAuth, add your deployed domains (and `http://localhost:8787` for local testing) as authorized origins and callback URLs in the Google Cloud Console.
 
 5. **Generate and apply database migrations** – Use Drizzle Kit to keep D1 in sync.
 

--- a/README.md
+++ b/README.md
@@ -42,19 +42,18 @@ Follow this path to fork the project, wire it into your Cloudflare account, and 
 4. **Configure authentication secrets and email provider** – Generate a random `BETTER_AUTH_SECRET`, create a Resend API key, and register the default "from" identity used by transactional email. When enabling Google sign-in, also create an OAuth Client ID (Web application) in the Google Cloud Console and capture the client ID/secret.
 
    ```bash
-   wrangler secret put BETTER_AUTH_SECRET
    wrangler secret put RESEND_API_KEY
+   wrangler secret put BETTER_AUTH_SECRET
    wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_ID
    wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_SECRET
    # for preview environment
-   wrangler secret put BETTER_AUTH_SECRET --env preview
    wrangler secret put RESEND_API_KEY --env preview
+   wrangler secret put BETTER_AUTH_SECRET --env preview
    wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_ID --env preview
    wrangler secret put BETTER_AUTH_GOOGLE_CLIENT_SECRET --env preview
    ```
 
    Update `DEFAULT_EMAIL_FROM_ADDRESS` and `DEFAULT_EMAIL_FROM_NAME` in `wrangler.jsonc` to match your verified sender.
-   For Google OAuth, add your deployed domains (and `http://localhost:8787` for local testing) as authorized origins and callback URLs in the Google Cloud Console.
 
 5. **Generate and apply database migrations** – Use Drizzle Kit to keep D1 in sync.
 

--- a/cloudflare-env.secrets.d.ts
+++ b/cloudflare-env.secrets.d.ts
@@ -5,6 +5,8 @@ declare global {
     RESEND_API_KEY: string;
     BETTER_AUTH_SECRET: string;
     SENTRY_RELEASE: string;
+    BETTER_AUTH_GOOGLE_CLIENT_ID: string;
+    BETTER_AUTH_GOOGLE_CLIENT_SECRET: string;
   }
 }
 

--- a/src/components/auth-status-card.tsx
+++ b/src/components/auth-status-card.tsx
@@ -13,7 +13,7 @@ export function AuthStatusCard() {
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [activeAction, setActiveAction] = useState<'login' | 'register' | null>(null);
+  const [activeAction, setActiveAction] = useState<'login' | 'register' | 'google' | null>(null);
   const [emailInput, setEmailInput] = useState('');
   const [passwordInput, setPasswordInput] = useState('');
   const [isEmailVerified, setIsEmailVerified] = useState<boolean | null>(null);
@@ -117,6 +117,29 @@ export function AuthStatusCard() {
       await refreshSession(credentials.email);
       setPasswordInput('');
       setInfo('Account created successfully.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setIsLoading(false);
+      setActiveAction(null);
+    }
+  };
+
+  const handleGoogleSignIn = async () => {
+    setIsLoading(true);
+    setActiveAction('google');
+    setError(null);
+    setInfo(null);
+    try {
+      const { error } = await authClient.signIn.social({
+        provider: 'google',
+        callbackURL: window.location.href,
+      });
+      if (error) {
+        setError(error.message ?? 'Unknown error');
+      } else {
+        setInfo('Redirecting to Google for authentication...');
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {
@@ -259,6 +282,14 @@ export function AuthStatusCard() {
           </Button>
         ) : (
           <>
+            <Button
+              variant="outline"
+              onClick={handleGoogleSignIn}
+              disabled={isLoading || status === 'checking'}
+              className="w-full flex-1 sm:flex-none"
+            >
+              {isLoading && activeAction === 'google' ? 'Redirecting…' : 'Sign in with Google'}
+            </Button>
             <Button
               onClick={handleLogin}
               disabled={isLoading || status === 'checking'}

--- a/src/components/auth-status-card.tsx
+++ b/src/components/auth-status-card.tsx
@@ -133,7 +133,6 @@ export function AuthStatusCard() {
     try {
       const { error } = await authClient.signIn.social({
         provider: 'google',
-        callbackURL: window.location.href,
       });
       if (error) {
         setError(error.message ?? 'Unknown error');

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { google } from 'better-auth/providers/google';
+import { google } from 'better-auth/social-providers';
 import { drizzle as drizzleD1 } from 'drizzle-orm/d1';
 
 import * as authSchema from '@/db/auth-schema';

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,5 @@
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { google } from 'better-auth/social-providers';
 import { drizzle as drizzleD1 } from 'drizzle-orm/d1';
 
 import * as authSchema from '@/db/auth-schema';
@@ -40,12 +39,12 @@ export async function createAuth(env: CloudflareEnv) {
       provider: 'sqlite',
       schema: authSchema,
     }),
-    providers: [
-      google({
+    socialProviders: {
+      google: {
         clientId: env.BETTER_AUTH_GOOGLE_CLIENT_ID,
         clientSecret: env.BETTER_AUTH_GOOGLE_CLIENT_SECRET,
-      }),
-    ],
+      },
+    },
     ...baseBetterAuthOptions,
     trustedOrigins,
   });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { google } from 'better-auth/providers/google';
 import { drizzle as drizzleD1 } from 'drizzle-orm/d1';
 
 import * as authSchema from '@/db/auth-schema';
@@ -39,6 +40,12 @@ export async function createAuth(env: CloudflareEnv) {
       provider: 'sqlite',
       schema: authSchema,
     }),
+    providers: [
+      google({
+        clientId: env.BETTER_AUTH_GOOGLE_CLIENT_ID,
+        clientSecret: env.BETTER_AUTH_GOOGLE_CLIENT_SECRET,
+      }),
+    ],
     ...baseBetterAuthOptions,
     trustedOrigins,
   });


### PR DESCRIPTION
## Summary
- enable the Better Auth Google OAuth provider and wire it to Cloudflare secrets
- document the new secrets and setup steps for Google sign-in
- add a Google sign-in button to the AuthStatusCard component

## Testing
- npm run lint *(warns about pre-existing import/no-anonymous-default-export in next-intl.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e7993ae5c8832db02504c31d1b21a0