### PR TITLE
feat: add long running test api

### DIFF
--- a/src/app/api/long-running/route.ts
+++ b/src/app/api/long-running/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+
+const MAX_SLEEP_MS = 5 * 60_000; // 5 minutes
+
+function parseSleepParam(url: string) {
+  const { searchParams } = new URL(url);
+  const sleepParam = searchParams.get('sleep');
+
+  if (!sleepParam) {
+    return { error: 'Missing "sleep" query parameter specifying the duration in milliseconds.' } as const;
+  }
+
+  const sleepMs = Number.parseInt(sleepParam, 10);
+
+  if (!Number.isFinite(sleepMs) || sleepMs < 0) {
+    return { error: 'The "sleep" value must be a non-negative integer representing milliseconds.' } as const;
+  }
+
+  if (sleepMs > MAX_SLEEP_MS) {
+    return {
+      error: `The requested sleep duration exceeds the maximum of ${MAX_SLEEP_MS} milliseconds.`,
+    } as const;
+  }
+
+  return { sleepMs } as const;
+}
+
+export async function GET(request: Request) {
+  const result = parseSleepParam(request.url);
+
+  if ('error' in result) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: result.error,
+      },
+      { status: 400 },
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, result.sleepMs));
+
+  return NextResponse.json({
+    ok: true,
+    sleptMs: result.sleepMs,
+  });
+}


### PR DESCRIPTION
## Summary
- add an /api/long-running endpoint that delays its response for the requested duration
- validate the sleep query parameter and cap the wait time to five minutes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e798e5cc30832da0decd31bf8f7715