### PR TITLE
feat: refresh login experience

### DIFF
--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,5 +1,7 @@
-export default {
+const nextIntlConfig = {
   locales: ['en', 'zh'],
   defaultLocale: 'en',
   localePrefix: 'never',
 };
+
+export default nextIntlConfig;


### PR DESCRIPTION
## Summary
- add mode selector, icons, and contextual hints to the Better Auth login card
- improve button feedback during authentication flows and polish form styling
- export next-intl configuration via a named constant to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e8b5d76238832da5ce51331de2a035