### PR TITLE
Adjust create account button styling

### DIFF
--- a/src/components/auth-status-card.tsx
+++ b/src/components/auth-status-card.tsx
@@ -352,6 +352,7 @@ export function AuthStatusCard() {
                   type="button"
                   disabled={isLoading}
                   className="w-full"
+                  variant="secondary"
                   onClick={() => {
                     void handleRegister();
                   }}


### PR DESCRIPTION
## Summary
- update the create account button in the auth status card to use the secondary button variant so it contrasts with Sign in

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8eed8a46c832da65929ac1246c7f6